### PR TITLE
Update README: document branch protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Home Assistant configuration for the [MakeNashville](https://makenashville.org) 
 
 ## Deploy
 
-Pushing to `main` automatically deploys to the HA instance via GitHub Actions (`.github/workflows/deploy.yml`). Changes to `automations.yaml`, `scripts.yaml`, or `configuration.yaml` trigger a `git pull` on the HA host followed by a config reload.
+Merging a PR to `main` automatically deploys to the HA instance via GitHub Actions (`.github/workflows/deploy.yml`). Changes to `automations.yaml`, `scripts.yaml`, or `configuration.yaml` trigger a `git pull` on the HA host followed by a config reload.
+
+**`main` is a protected branch — all changes must go through a pull request.** Direct pushes are not allowed.
 
 ### Initial HA host setup
 


### PR DESCRIPTION
## Summary
- Clarifies that deploys happen on PR merge, not direct push
- Notes that `main` is protected and requires a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)