### PR TITLE
Improve Roundup automation

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -258,12 +258,22 @@
           {%- set obj = states('sensor.' ~ p.id ~ '_object') %}
           {%- set display = p.id | capitalize if display in ['unknown','unavailable',''] else display %}
           {%- set obj = display if obj in ['unknown','unavailable',''] else obj %}
+          {%- set status_labels = {
+            'idle': 'Ready',
+            'finish': 'Finished',
+            'failed': 'Stopped',
+            'error': 'Error',
+            'pause': 'Paused',
+            'offline': 'Offline',
+            'unavailable': 'Offline',
+            'unknown': 'Offline',
+          } %}
           {%- if st not in not_printing %}
             {%- set progress = states('sensor.' ~ p.id ~ '_print_progress') %}
             {%- set end_dt = as_datetime(states('sensor.' ~ p.id ~ '_end_time'), none) %}
             {{- p.emoji }} @{{ display }} printing {{ obj }} — {{ progress }}%{%- if end_dt %}, ends {{ end_dt | as_local | strftime('%I:%M %p') }}{%- endif %}
           {%- else %}
-            {{- p.emoji }} {{ st }}
+            {{- p.emoji }} {{ status_labels.get(st, st | capitalize) }}
           {%- endif %}
         {%- endmacro %}
         Bi-hourly roundup — {{ ns.active }} printer{{ 's' if ns.active != 1 else '' }} active


### PR DESCRIPTION
## Summary
- **Skip when idle** — condition checks if any printer is active before firing
- **Add pineapple** — added to printer list with :pineapple: emoji
- **Print progress %** — active prints now show completion percentage
- **Formatted end time** — `ends 3:45 PM` instead of raw sensor state
- **Updated not_printing list** — now includes `error` and `unknown`
- **Better header** — `Bi-hourly roundup — 3 printers active` instead of generic text
- **Graceful fallback** — if `_display_name`/`_object` unavailable for a printer, falls back to capitalized printer name

## Test plan
- [ ] Confirm no message fires when all printers are idle
- [ ] Confirm message fires and shows correct data when a print is active
- [ ] Confirm pineapple appears in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)