### PR TITLE
Add OctoEverywhere Gadget AI failure detection webhook

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -512,6 +512,40 @@
         username: Facilities Pulse
       target: '#facilities-feed'
   mode: single
+- id: '1740400000000'
+  alias: Gadget AI Failure Detection
+  description: Receives OctoEverywhere Gadget webhooks for Bambu Lab printers
+  triggers:
+  - trigger: webhook
+    webhook_id: octoeverywhere_gadget
+    allowed_methods:
+    - POST
+    local_only: false
+  conditions:
+  - condition: template
+    value_template: '{{ trigger.json.EventType in [7, 8] }}'
+  actions:
+  - variables:
+      event_type: '{{ trigger.json.EventType }}'
+      printer_name: '{{ trigger.json.PrinterName }}'
+      printer_id: '{{ trigger.json.PrinterName | lower }}'
+      file_name: '{{ trigger.json.FileName | default("") }}'
+      progress: '{{ trigger.json.Progress | default(0) }}'
+      quick_view_url: '{{ trigger.json.QuickViewUrl | default("") }}'
+      stream_url: '{{ states("input_text." + printer_id + "_stream") }}'
+  - action: notify.make_nashville
+    data:
+      target: '#3dprint-info'
+      message: '{% if event_type == 8 %}🚨 Gadget paused {{ printer_name }} after
+        detecting a failure{% else %}⚠️ Gadget detected a possible failure on {{
+        printer_name }}{% endif %}{% if file_name %} printing {{ file_name }}{% endif
+        %} ({{ progress }}% complete).{% if quick_view_url %} {{ quick_view_url }}{%
+        endif %} {{ stream_url }}'
+      data:
+        username: Gadget
+        icon: robot_face
+  mode: parallel
+  max: 5
 - id: '1769999000001'
   alias: Purge Kaeser Pressure History
   description: Keep only 3 days of Kaeser pressure data to limit DB growth


### PR DESCRIPTION
## Summary
- Single webhook automation handles all 5 Bambu Lab printers
- Triggers on EventType 7 (possible failure warning ⚠️) and 8 (Gadget paused print 🚨)
- Posts to `#3dprint-info` with printer name, file, progress %, QuickView URL, and stream URL

## Setup in OctoEverywhere
For each Bambu Lab printer, go to OctoEverywhere → Notifications → Webhooks and set the URL to:
```
https://<your-ha-url>/api/webhook/octoeverywhere_gadget
```
Enable **Gadget** notification events. The automation handles all printers from a single endpoint.

> **Note:** `printer_id` is derived from `PrinterName | lower` — make sure the printer names in OctoEverywhere match the HA entity prefixes (e.g. OctoEverywhere name "Kiwi" → `input_text.kiwi_stream`).

## Test plan
- [ ] Send a test webhook from OctoEverywhere and confirm Slack message fires
- [ ] Confirm stream URL appears in message

🤖 Generated with [Claude Code](https://claude.com/claude-code)