### PR TITLE
Config improvements: offline alert, YAML anchors, deploy hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,10 @@ on:
     paths:
       - automations.yaml
       - scripts.yaml
+      - scenes.yaml
       - configuration.yaml
       - git_backup.sh
+      - themes/**
       - esphome/**
 
 jobs:
@@ -21,9 +23,18 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/shell_command/git_pull"
 
-      # Give git pull a moment to finish before reloading
+      # Give git pull a moment to finish before validating
       - name: Wait for pull
         run: sleep 5
+
+      - name: Validate config
+        run: |
+          result=$(curl -f -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            "${{ secrets.HA_URL }}/api/config/core/check_config")
+          echo "$result"
+          echo "$result" | jq -e '.result == "valid"'
 
       - name: Reload automations
         run: |
@@ -39,9 +50,31 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/script/reload"
 
+      - name: Reload scenes
+        run: |
+          curl -f -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            "${{ secrets.HA_URL }}/api/services/scene/reload"
+
+      - name: Reload themes
+        run: |
+          curl -f -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            "${{ secrets.HA_URL }}/api/services/frontend/reload_themes"
+
       - name: Reload core config (templates)
         run: |
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/homeassistant/reload_core_config"
+
+      - name: Notify deployment
+        run: |
+          curl -f -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"target": "#deployment-feed", "message": "✅ Config deployed successfully from GitHub.", "data": {"username": "GitHub Actions", "icon": "github"}}' \
+            "${{ secrets.HA_URL }}/api/services/notify/make_nashville"

--- a/automations.yaml
+++ b/automations.yaml
@@ -79,7 +79,7 @@
   alias: Lifecycle Print Starting
   description: ''
   triggers:
-  - entity_id:
+  - entity_id: &bambu_status
     - sensor.mango_print_status
     - sensor.kiwi_print_status
     - sensor.strawberry_print_status
@@ -142,12 +142,7 @@
   alias: Lifecycle Print Finished
   description: ''
   triggers:
-  - entity_id:
-    - sensor.mango_print_status
-    - sensor.kiwi_print_status
-    - sensor.strawberry_print_status
-    - sensor.papaya_print_status
-    - sensor.huckleberry_print_status
+  - entity_id: *bambu_status
     to:
     - finish
     for:
@@ -195,12 +190,7 @@
   alias: Lifecycle Print Stopped
   description: ''
   triggers:
-  - entity_id:
-    - sensor.mango_print_status
-    - sensor.kiwi_print_status
-    - sensor.strawberry_print_status
-    - sensor.papaya_print_status
-    - sensor.huckleberry_print_status
+  - entity_id: *bambu_status
     to:
     - failed
     for:
@@ -243,7 +233,7 @@
   alias: Lifecycle Print Error
   description: ''
   triggers:
-  - entity_id:
+  - entity_id: &all_status
     - sensor.mango_print_status
     - sensor.kiwi_print_status
     - sensor.strawberry_print_status
@@ -280,12 +270,7 @@
   alias: Lifecycle Print Paused
   description: ''
   triggers:
-  - entity_id:
-    - sensor.mango_print_status
-    - sensor.kiwi_print_status
-    - sensor.strawberry_print_status
-    - sensor.papaya_print_status
-    - sensor.huckleberry_print_status
+  - entity_id: *bambu_status
     to:
     - pause
     for:
@@ -383,7 +368,8 @@
             {%- set _end_raw = as_datetime(states('sensor.' ~ p.id ~ '_end_time'), none) %}
             {%- set _tl = states('sensor.' ~ p.id ~ '_print_time_left') | int(0) %}
             {%- set end_dt = _end_raw if _end_raw else (now() + timedelta(seconds=_tl) if _tl > 0 else none) %}
-            {{- p.emoji }} @{{ display }} printing {{ obj }} — {{ progress }}%{%- if end_dt %}, ends {{ as_timestamp(end_dt) | timestamp_custom('%I:%M %p') }}{%- endif %}
+            {%- set verb = 'paused on' if st in ['pause', 'paused'] else 'printing' %}
+            {{- p.emoji }} @{{ display }} {{ verb }} {{ obj }} — {{ progress }}%{%- if end_dt %}, ends {{ as_timestamp(end_dt) | timestamp_custom('%I:%M %p') }}{%- endif %}
           {%- else %}
             {{- p.emoji }} {{ status_labels.get(st, st | capitalize) }}
           {%- endif %}
@@ -622,3 +608,28 @@
       - sensor.kaeser_monitor_system_pressure
       keep_days: 3
   mode: single
+- id: '1740500000001'
+  alias: Lifecycle Printer Offline
+  description: ''
+  triggers:
+  - entity_id: *all_status
+    to:
+    - unavailable
+    for:
+      hours: 0
+      minutes: 5
+      seconds: 0
+    trigger: state
+  conditions: []
+  actions:
+  - variables:
+      printer: '{{trigger.entity_id.split(''_'')[0].split(''.'')[1]}}'
+  - data:
+      target: '#3dprint-info'
+      message: '⚠️ {{ printer | capitalize }} has gone offline.'
+      data:
+        username: '{{ printer | capitalize }}'
+        icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+    action: notify.make_nashville
+  mode: parallel
+  max: 6


### PR DESCRIPTION
## Summary

- **YAML anchors**: `&bambu_status` (5 Bambu printers) and `&all_status` (all 6) replace repeated entity ID lists across lifecycle automations — adding a printer is now a one-line change in two places. Note: anchors expand if an automation is saved via the HA UI.
- **New: Lifecycle Printer Offline**: alerts `#3dprint-info` when any printer goes `unavailable` for 5+ minutes
- **Roundup fix**: paused printers now show "paused on X" instead of "printing X"
- **deploy.yml paths**: now triggers on `scenes.yaml` and `themes/**` changes
- **Config validation**: calls `/api/config/core/check_config` after pull and fails the job before any reload if config is invalid
- **Reload scenes and themes**: added `scene/reload` and `frontend/reload_themes` steps
- **Deploy notification**: posts ✅ to `#deployment-feed` on successful deploy

## Test plan

- [ ] Merge and verify GitHub Actions passes with a config change
- [ ] Unplug a printer for 5+ minutes and confirm `#3dprint-info` alert
- [ ] Pause a print and check Roundup shows "paused on" instead of "printing"
- [ ] Push a deliberate YAML error and confirm the job fails at Validate step (then revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)