### PR TITLE
Fix pineapple last-job tracking, Roundup prepare state, weekly metrics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Notify deployment
         run: |
-          curl -f -s -X POST \
+          curl -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d '{"target": "#deployment-feed", "message": "✅ Config deployed successfully from GitHub.", "data": {"username": "GitHub Actions", "icon": "github"}}' \

--- a/automations.yaml
+++ b/automations.yaml
@@ -136,6 +136,15 @@
         username: '{{ printer | capitalize }}'
         icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
     action: notify.make_nashville
+  - if:
+    - condition: template
+      value_template: "{{ printer == 'pineapple' }}"
+    then:
+    - action: input_text.set_value
+      target:
+        entity_id: input_text.pineapple_last_job
+      data:
+        value: "{{ states('sensor.pineapple_current_object') }}"
   mode: parallel
   max: 4
 - id: '1722191155564'
@@ -318,7 +327,7 @@
   - condition: template
     value_template: |-
       {% set printers = ['kiwi','mango','papaya','strawberry','huckleberry','pineapple'] %}
-      {% set not_printing = ['unavailable','idle','offline','finish','failed','completed','stopped','error','unknown'] %}
+      {% set not_printing = ['unavailable','idle','offline','finish','failed','completed','stopped','error','unknown','prepare'] %}
       {% set ns = namespace(active=false) %}
       {% for p in printers %}{% if states('sensor.' ~ p ~ '_print_status') not in not_printing %}{% set ns.active = true %}{% endif %}{% endfor %}
       {{ ns.active }}
@@ -337,7 +346,7 @@
           {"id":"huckleberry","emoji":":huckleberry:"},
           {"id":"pineapple","emoji":":pineapple:"},
         ] %}
-        {%- set not_printing = ['unavailable','idle','offline','finish','failed','completed','stopped','error','unknown'] %}
+        {%- set not_printing = ['unavailable','idle','offline','finish','failed','completed','stopped','error','unknown','prepare'] %}
         {%- set ns = namespace(active=0) %}
         {%- for p in printers %}
           {%- if states('sensor.' ~ p.id ~ '_print_status') not in not_printing %}
@@ -352,6 +361,7 @@
           {%- set obj = display if obj in ['unknown','unavailable',''] else obj %}
           {%- set status_labels = {
             'idle': 'Ready',
+            'prepare': 'Preparing',
             'finish': 'Finished',
             'completed': 'Finished',
             'failed': 'Stopped',
@@ -633,3 +643,40 @@
     action: notify.make_nashville
   mode: parallel
   max: 6
+- id: '1740600000001'
+  alias: Weekly Print Summary
+  description: Posts 7-day print totals to #3dprint-info every Sunday at 9am
+  triggers:
+  - trigger: time
+    at: '09:00:00'
+  conditions:
+  - condition: template
+    value_template: '{{ now().weekday() == 6 }}'
+  actions:
+  - action: notify.make_nashville
+    data:
+      target: '#3dprint-info'
+      data:
+        username: Fruitbasket
+        icon: basket
+      message: |-
+        {%- set printers = [
+          {"id":"kiwi","emoji":":kiwifruit:"},
+          {"id":"mango","emoji":":mango:"},
+          {"id":"papaya","emoji":":papaya:"},
+          {"id":"strawberry","emoji":":strawberry:"},
+          {"id":"huckleberry","emoji":":huckleberry:"},
+          {"id":"pineapple","emoji":":pineapple:"},
+        ] %}
+        {%- set ns = namespace(total_ok=0, total_fail=0) %}
+        📊 Weekly Print Summary (last 7 days)
+        {%- for p in printers %}
+          {%- set ok = states('sensor.' ~ p.id ~ '_prints_completed_week') | int(0) %}
+          {%- set fail = states('sensor.' ~ p.id ~ '_prints_failed_week') | int(0) %}
+          {%- set ns.total_ok = ns.total_ok + ok %}
+          {%- set ns.total_fail = ns.total_fail + fail %}
+        {{ p.emoji }} {{ p.id | capitalize }}: {{ ok }} ✅  {{ fail }} ❌
+        {%- endfor %}
+        ──────────────────────
+        Total: {{ ns.total_ok }} ✅  {{ ns.total_fail }} ❌
+  mode: single

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -16,6 +16,11 @@ homeassistant:
 shell_command:
   git_pull: "git -C /config pull --rebase origin main"
 
+input_text:
+  pineapple_last_job:
+    name: Pineapple Last Job
+    max: 255
+
 recorder:
   purge_keep_days: 14
   exclude:
@@ -126,10 +131,10 @@ template:
           {{states('sensor.pineapple_current_object').replace(states('sensor.pineapple_display_name') + '-', '')}}
       - name: "Pineapple Last Display Name"
         state: >
-          {{states('sensor.pineapple_current_object').split('-')[0]}}
+          {{states('input_text.pineapple_last_job').split('-')[0]}}
       - name: "Pineapple Last Object"
         state: >
-          {{states('sensor.pineapple_current_object').replace(states('sensor.pineapple_last_display_name') + '-', '')}}
+          {{states('input_text.pineapple_last_job').replace(states('sensor.pineapple_last_display_name') + '-', '')}}
 
       - name: "Dragonfruit Display Name"
         state: >
@@ -137,3 +142,90 @@ template:
       - name: "Dragonfruit Object"
         state: >
           {{states('sensor.dragonfruit_filename').replace(states('sensor.dragonfruit_display_name') + '-', '')}}
+
+sensor:
+  # Weekly print counts — used by the Sunday metrics automation
+  - platform: history_stats
+    name: Kiwi Prints Completed Week
+    entity_id: sensor.kiwi_print_status
+    state: "finish"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Kiwi Prints Failed Week
+    entity_id: sensor.kiwi_print_status
+    state: "failed"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Mango Prints Completed Week
+    entity_id: sensor.mango_print_status
+    state: "finish"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Mango Prints Failed Week
+    entity_id: sensor.mango_print_status
+    state: "failed"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Papaya Prints Completed Week
+    entity_id: sensor.papaya_print_status
+    state: "finish"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Papaya Prints Failed Week
+    entity_id: sensor.papaya_print_status
+    state: "failed"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Strawberry Prints Completed Week
+    entity_id: sensor.strawberry_print_status
+    state: "finish"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Strawberry Prints Failed Week
+    entity_id: sensor.strawberry_print_status
+    state: "failed"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Huckleberry Prints Completed Week
+    entity_id: sensor.huckleberry_print_status
+    state: "finish"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Huckleberry Prints Failed Week
+    entity_id: sensor.huckleberry_print_status
+    state: "failed"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Pineapple Prints Completed Week
+    entity_id: sensor.pineapple_print_status
+    state: "completed"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Pineapple Prints Failed Week
+    entity_id: sensor.pineapple_print_status
+    state: "stopped"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"


### PR DESCRIPTION
## Summary

- **Pineapple Print Finished name fix**: `_last_display_name` and `_last_object` templates were reading from `sensor.pineapple_current_object` which clears after a print completes. Added `input_text.pineapple_last_job` helper — Print Starting now saves the current object when pineapple starts, and the Last templates read from the helper instead.
- **Roundup `prepare` state**: Bambu printers in warmup (`prepare`) were showing as active printing at 0%. Added `prepare` to `not_printing` in both the condition and the macro, and added a "Preparing" status label.
- **Weekly Print Summary**: new automation fires Sundays at 9am, posts a 7-day ✅/❌ count per printer to `#3dprint-info`. Backed by 12 `history_stats` sensors added to `configuration.yaml`.
- **Deploy notify**: removed `-f` from the notify curl so a Slack failure doesn't mark the deploy job as failed.

## Test plan

- [ ] Start and finish a Pineapple print — verify Print Finished shows the correct job name
- [ ] Wait for a Bambu printer to enter `prepare` state — verify it doesn't appear in the Roundup
- [ ] Trigger the Weekly Summary automation manually and confirm message format
- [ ] Verify GitHub Actions deploy still succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)