### PR TITLE
Fix unclosed quote on Lifecycle Print Finished message

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -166,7 +166,7 @@
       target: "{{ (states('input_text.slack_channel_3dprint') or '#sandbox') }}"
       message: ":white_check_mark:{% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
         finished in {{job_time_str}}{% if used_weight %}, used {{used_weight}}{% endif
-        %}! Please pick up your print and cleanup the space. {{states('input_text.'+printer+'_stream')}}
+        %}! Please pick up your print and cleanup the space. {{states('input_text.'+printer+'_stream')}}"
       data:
         username: '{{ printer | capitalize }}'
         icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'


### PR DESCRIPTION
## Summary

- The `✅` → `":white_check_mark:` emoji replacement added an opening `"` to a bare YAML scalar in the Lifecycle Print Finished Slack message without adding a matching closing `"`
- Adds the missing closing quote

## Test plan

- [ ] Run Check Configuration in HA — should return valid with no YAML errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)