### PR TITLE
Fix remaining inline YAML keys; add PR validation workflow

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -1,0 +1,50 @@
+name: Validate YAML
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate YAML files
+        run: |
+          python3 - <<'EOF'
+          import yaml, sys, glob
+
+          class PassThruLoader(yaml.SafeLoader):
+              pass
+
+          for tag in ('!include', '!include_dir_merge_named', '!include_dir_list',
+                      '!include_dir_merge_list', '!include_dir_named', '!secret',
+                      '!env_var', '!input'):
+              PassThruLoader.add_constructor(tag, lambda loader, node: loader.construct_scalar(node))
+
+          files = (
+              glob.glob('*.yaml') +
+              glob.glob('dashboards/*.yaml') +
+              glob.glob('esphome/*.yaml')
+          )
+          ok = True
+          for f in sorted(files):
+              try:
+                  with open(f) as fh:
+                      yaml.load(fh, Loader=PassThruLoader)
+                  print(f'OK  {f}')
+              except yaml.YAMLError as e:
+                  print(f'ERR {f}: {e}')
+                  ok = False
+          sys.exit(0 if ok else 1)
+          EOF

--- a/automations.yaml
+++ b/automations.yaml
@@ -366,7 +366,8 @@
     for:
       minutes: 2
   actions:
-  - action: notify.mobile_app_tim_krentz_iphone    data:
+  - action: notify.mobile_app_tim_krentz_iphone
+    data:
       message: Kaeser Overpressurization Event!
   - action: notify.make_nashville
     data:
@@ -397,7 +398,8 @@
     data:
       message: >-
         {{ now().isoformat() }},{{ (trigger.json.data.object.amount | default(0)) / 100 | round(2) }},"{{ trigger.json.data.object.description | default('') }}"
-  - action: light.turn_on    target:
+  - action: light.turn_on
+    target:
       entity_id: light.filament_store_light
     data:
       rgb_color:
@@ -407,7 +409,8 @@
       brightness_pct: 100
   - delay:
       seconds: 30
-  - action: light.turn_on    target:
+  - action: light.turn_on
+    target:
       entity_id: light.filament_store_light
     data:
       rgb_color:
@@ -500,7 +503,8 @@
               trigger.entity_id in ['sensor.total_power_alarm_power_failure_alarm', 'binary_sensor.water_leak_sensor'] or
               (trigger.from_state.state | float(0) - trigger.to_state.state | float(0)) | abs > 5) }}
   actions:
-  - action: notify.make_nashville    data:
+  - action: notify.make_nashville
+    data:
       target: "{{ (states('input_text.slack_channel_facilities') or '#sandbox') }}"
       data:
         icon: warning
@@ -548,7 +552,8 @@
   - condition: template
     value_template: "{{ is_state('input_boolean.facilities_pulse_verbose', 'on') }}"
   actions:
-  - action: notify.make_nashville    data:
+  - action: notify.make_nashville
+    data:
       target: "{{ (states('input_text.slack_channel_facilities') or '#sandbox') }}"
       data:
         icon: information_source


### PR DESCRIPTION
## Summary

- Five more `action`/`data`/`target` keys were appended inline on the same line in the HA-exported YAML format (same issue as the `triggers:`/`actions:` fix in #17) — all split onto their own lines
- Adds `.github/workflows/validate-yaml.yml`: runs PyYAML validation against all `*.yaml`, `dashboards/*.yaml`, and `esphome/*.yaml` files on every PR and push to main, with pass-through constructors for HA-specific tags (`!include`, `!secret`, etc.)

## Test plan

- [ ] Run Check Configuration in HA — should return valid
- [ ] Confirm the Actions workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)