### PR TITLE
Fix: rename air-quality dashboard key to airquality

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -13,7 +13,7 @@ homeassistant:
 
 lovelace:
   dashboards:
-    air-quality:
+    airquality:
       mode: yaml
       title: Air Quality
       icon: mdi:air-filter


### PR DESCRIPTION
## Summary

- Renames the Lovelace dashboard key from `air-quality` to `airquality` — hyphens are not valid in dashboard keys.

## Test plan

- [ ] Air Quality dashboard loads in HA sidebar without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)