### PR TITLE
Air quality dashboard, automation refactors, and notify migration

### DIFF
--- a/automations/backup.yaml
+++ b/automations/backup.yaml
@@ -8,13 +8,7 @@
     event: start
   actions:
   - sequence:
-    - action: shell_command.clear_entity_list
-    - action: notify.entity_list_file
-      data:
-        message: |-
-          {% for s in states | sort(attribute='entity_id') %}
-          {{ s.entity_id }} | {{ s.name }}
-          {%- endfor %}
+    - action: python_script.write_entity_list
     - action: hassio.addon_stdin
       data:
         addon: core_ssh

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -28,15 +28,7 @@ lovelace:
       show_in_sidebar: true
       require_admin: false
 
-notify:
-  - name: entity_list_file
-    platform: file
-    filename: /config/entity_list.txt
-    timestamp: false
-  - name: filament_purchases_log
-    platform: file
-    filename: /config/filament_purchases.csv
-    timestamp: false
+python_script:
 
 shell_command:
   git_pull: "git -C /config pull --rebase origin main"

--- a/python_scripts/write_entity_list.py
+++ b/python_scripts/write_entity_list.py
@@ -1,0 +1,3 @@
+with open("/config/entity_list.txt", "w") as f:
+    for state in sorted(hass.states.async_all(), key=lambda s: s.entity_id):
+        f.write(f"{state.entity_id} | {state.name}\n")


### PR DESCRIPTION
## Summary

- Adds air quality dashboard for the 3D print room with calibrated thresholds and alerts
- Splits automations into per-system files for easier maintenance
- Replaces deprecated `notify` file platform with `python_script` to fix broken entity list backup
- Fixes Lovelace dashboard key formatting and various YAML parse errors

## Test plan

- [ ] Air quality dashboard loads and displays sensor data correctly
- [ ] Backup automation runs without error on HA start and at 3:00 AM
- [ ] `entity_list.txt` is written correctly after restart
- [ ] All automations reload cleanly after config reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)