### PR TITLE
Remove broken lovelace/reload_resources deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,13 +60,6 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/scene/reload"
 
-      - name: Reload Lovelace dashboards
-        run: |
-          curl -f -s -X POST \
-            -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            "${{ secrets.HA_URL }}/api/services/lovelace/reload_resources"
-
       - name: Reload themes
         run: |
           curl -f -s -X POST \


### PR DESCRIPTION
## Summary

- Removes the `Reload Lovelace dashboards` step from the deploy workflow — `lovelace/reload_resources` no longer exists in newer HA versions and was causing deploy failures
- YAML-mode dashboards are read from disk on request, so no explicit reload call is needed

## Test plan

- [ ] Merge and verify the next deploy run completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)