### PR TITLE
Send air quality alerts to #integration-sandbox

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -135,7 +135,7 @@
   mode: single
 - id: '1740600000002'
   alias: Air Quality Alert
-  description: Notify #facilities-feed when 3D print room air quality degrades or recovers
+  description: Notify #integration-sandbox when 3D print room air quality degrades or recovers
   triggers:
   - trigger: state
     entity_id: sensor.air_quality_overall_status
@@ -170,7 +170,7 @@
       sequence:
       - action: notify.make_nashville
         data:
-          target: "#facilities-feed"
+          target: "#integration-sandbox"
           message: >
             {% if status == 'Dangerous' %}:no_entry:{% else %}:warning:{% endif %} *3D Print Room Air Quality: {{ status }}*
             CO2: {{ co2 }} ppm | VOC: {{ voc }} | NOx: {{ nox }} | PM2.5: {{ pm25 }} ug/m3.
@@ -192,7 +192,7 @@
       sequence:
       - action: notify.make_nashville
         data:
-          target: "#facilities-feed"
+          target: "#integration-sandbox"
           message: ':white_check_mark: 3D print room air quality has returned to {{ status }}. CO2: {{ co2 }} ppm | VOC: {{ voc }} | PM2.5: {{ pm25 }} ug/m3.'
           data:
             username: Air Quality


### PR DESCRIPTION
## Summary

- Routes air quality degradation and recovery alerts to `#integration-sandbox` instead of `#facilities-feed` for testing

## Test plan

- [ ] Trigger an air quality state change and confirm the message lands in `#integration-sandbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)