### PR TITLE
Replace python_script entity list with shell script

### DIFF
--- a/automations/backup.yaml
+++ b/automations/backup.yaml
@@ -8,7 +8,7 @@
     event: start
   actions:
   - sequence:
-    - action: python_script.write_entity_list
+    - action: shell_command.write_entity_list
     - action: hassio.addon_stdin
       data:
         addon: core_ssh

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -28,11 +28,9 @@ lovelace:
       show_in_sidebar: true
       require_admin: false
 
-python_script:
-
 shell_command:
   git_pull: "git -C /config pull --rebase origin main"
-  clear_entity_list: "truncate -s 0 /config/entity_list.txt"
+  write_entity_list: "bash /config/write_entity_list.sh"
 
 input_text:
   pineapple_last_job:

--- a/write_entity_list.sh
+++ b/write_entity_list.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+python3 -c "
+import json
+with open('/config/.storage/core.entity_registry') as f:
+    data = json.load(f)
+entities = sorted(data['data']['entities'], key=lambda e: e['entity_id'])
+with open('/config/entity_list.txt', 'w') as out:
+    for e in entities:
+        name = e.get('name') or e.get('original_name', '')
+        out.write(f\"{e['entity_id']} | {name}\n\")
+"


### PR DESCRIPTION
## Summary

- Replaces the broken `python_script.write_entity_list` action with a `shell_command` that calls `write_entity_list.sh`
- The shell script reads directly from `.storage/core.entity_registry` using Python3 — no token, no deprecated integrations, no sandboxed environment
- Removes unused `python_script:` integration key and `clear_entity_list` shell command

## Why this approach

- `python_script` sandboxes `open()` — file I/O is not allowed
- `notify` file platform was fully removed in HA 2024.12 (UI-only now, not YAML-configurable)
- `.storage/core.entity_registry` is the authoritative entity source and readable by shell commands

## Test plan

- [ ] Trigger the backup automation and confirm `entity_list.txt` is written to `/config/`
- [ ] Verify the entity list contains correctly formatted `entity_id | name` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)