### PR TITLE
Detect restart vs reload requirement in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect if full restart required
+        id: restart_check
+        run: |
+          if git diff --name-only HEAD~1 HEAD | grep -qE '^(configuration\.yaml|python_scripts/)'; then
+            echo "required=true" >> $GITHUB_OUTPUT
+          else
+            echo "required=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Pull latest config on HA
         run: |
           curl -f -s -X POST \
@@ -39,7 +52,29 @@ jobs:
           echo "$result"
           echo "$result" | jq -e '.result == "valid"'
 
+      # --- Restart path ---
+
+      - name: Notify restart
+        if: steps.restart_check.outputs.required == 'true'
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"target": "#deployment-feed", "message": ":arrows_counterclockwise: Config deployed from GitHub — full restart required for core config changes. Restarting now.", "data": {"username": "GitHub Actions", "icon": "github"}}' \
+            "${{ secrets.HA_URL }}/api/services/notify/make_nashville"
+
+      - name: Restart HA
+        if: steps.restart_check.outputs.required == 'true'
+        run: |
+          curl -f -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            "${{ secrets.HA_URL }}/api/services/homeassistant/restart"
+
+      # --- Reload path ---
+
       - name: Reload automations
+        if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
@@ -47,6 +82,7 @@ jobs:
             "${{ secrets.HA_URL }}/api/services/automation/reload"
 
       - name: Reload scripts
+        if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
@@ -54,6 +90,7 @@ jobs:
             "${{ secrets.HA_URL }}/api/services/script/reload"
 
       - name: Reload scenes
+        if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
@@ -61,6 +98,7 @@ jobs:
             "${{ secrets.HA_URL }}/api/services/scene/reload"
 
       - name: Reload themes
+        if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
@@ -68,16 +106,18 @@ jobs:
             "${{ secrets.HA_URL }}/api/services/frontend/reload_themes"
 
       - name: Reload core config (templates)
+        if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/homeassistant/reload_core_config"
 
-      - name: Notify deployment
+      - name: Notify reload
+        if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"target": "#deployment-feed", "message": "✅ Config deployed successfully from GitHub.", "data": {"username": "GitHub Actions", "icon": "github"}}' \
+            -d '{"target": "#deployment-feed", "message": ":white_check_mark: Config deployed from GitHub — automations, scripts, scenes, and templates reloaded.", "data": {"username": "GitHub Actions", "icon": "github"}}' \
             "${{ secrets.HA_URL }}/api/services/notify/make_nashville"


### PR DESCRIPTION
## Summary

- Adds a checkout step and git diff to detect whether the push touched `configuration.yaml` or `python_scripts/` (which require a full restart) vs. automation/script/scene/theme files (which only need hot reloads)
- **Restart path**: notifies Slack first (before HA goes down), then calls `homeassistant/restart`
- **Reload path**: runs all reload steps as before, then notifies Slack

## Slack messages

| Scenario | Message |
|---|---|
| Restart required | `:arrows_counterclockwise: Config deployed from GitHub — full restart required for core config changes. Restarting now.` |
| Reload only | `:white_check_mark: Config deployed from GitHub — automations, scripts, scenes, and templates reloaded.` |

## Test plan

- [ ] Push a change to `configuration.yaml` — verify restart notification fires and HA restarts
- [ ] Push a change to `automations/` only — verify reload notification fires and no restart occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)