### PR TITLE
Push HA backups to ha-backup branch and auto-open PR to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # === SECRETS & CREDENTIALS ===
 secrets.yaml
+.github_token
 *.key
 *.pem
 *.crt

--- a/git_backup.sh
+++ b/git_backup.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# Commits changed config files, pushes to the ha-backup branch, and opens
+# (or surfaces) a PR to main. Requires a GitHub PAT at /config/.github_token
+# with repo scope to create PRs.
+
+set -euo pipefail
+
+GITHUB_TOKEN_FILE="/config/.github_token"
+BACKUP_BRANCH="ha-backup"
 
 notify() {
   local msg="$1"
@@ -13,14 +21,81 @@ notify() {
     http://supervisor/core/api/services/notify/make_nashville || true
 }
 
+open_or_find_pr() {
+  local github_token="$1"
+  local remote_url
+  remote_url=$(git remote get-url origin)
+
+  # Extract owner/repo from HTTPS or SSH remote URL
+  local owner_repo
+  if [[ "$remote_url" =~ github\.com[:/](.+/.+?)(\.git)?$ ]]; then
+    owner_repo="${BASH_REMATCH[1]}"
+  else
+    echo "WARNING: Could not parse GitHub remote URL, skipping PR"
+    return
+  fi
+
+  local owner="${owner_repo%%/*}"
+  local short_sha
+  short_sha=$(git rev-parse --short HEAD)
+  local commit_msg
+  commit_msg=$(git log -1 --pretty=%s)
+
+  local pr_body
+  pr_body=$(jq -n \
+    --arg title "HA Config Backup: ${commit_msg}" \
+    --arg body "Automated config backup from Home Assistant.\n\nLatest commit: \`${short_sha}\` — ${commit_msg}" \
+    --arg head "$BACKUP_BRANCH" \
+    --arg base "main" \
+    '{"title": $title, "body": $body, "head": $head, "base": $base}')
+
+  local response
+  response=$(curl -s -X POST \
+    -H "Authorization: Bearer $github_token" \
+    -H "Content-Type: application/json" \
+    -d "$pr_body" \
+    "https://api.github.com/repos/${owner_repo}/pulls")
+
+  local pr_url
+  pr_url=$(echo "$response" | jq -r '.html_url // empty')
+
+  if [ -n "$pr_url" ]; then
+    echo "PR opened: $pr_url"
+    notify ":arrow_up: Config backup PR opened: ${pr_url}"
+    return
+  fi
+
+  # PR already exists — find and surface it
+  pr_url=$(curl -s \
+    -H "Authorization: Bearer $github_token" \
+    "https://api.github.com/repos/${owner_repo}/pulls?head=${owner}:${BACKUP_BRANCH}&base=main&state=open" \
+    | jq -r '.[0].html_url // empty')
+
+  if [ -n "$pr_url" ]; then
+    echo "PR already open: $pr_url"
+    notify ":floppy_disk: Config backed up to GitHub. PR already open: ${pr_url}"
+  else
+    echo "WARNING: Could not create or find PR"
+    notify ":floppy_disk: Config backed up to GitHub (could not open PR)."
+  fi
+}
+
 cd /config
 git add .
+
 if ! git diff-index --quiet HEAD -- 2>/dev/null; then
   git commit -m "Auto backup: $(date +'%Y-%m-%d %H:%M:%S')"
+
   if git pull --rebase origin main; then
-    if git push origin main; then
-      notify ":floppy_disk: Config backed up to GitHub successfully."
-      echo "Backup completed successfully"
+    if git push --force origin HEAD:"$BACKUP_BRANCH"; then
+      echo "Backup pushed to $BACKUP_BRANCH"
+
+      if [ -f "$GITHUB_TOKEN_FILE" ]; then
+        open_or_find_pr "$(cat "$GITHUB_TOKEN_FILE")"
+      else
+        echo "No token at $GITHUB_TOKEN_FILE — skipping PR creation"
+        notify ":floppy_disk: Config backed up to ${BACKUP_BRANCH}. Add a GitHub token to /config/.github_token to auto-open PRs."
+      fi
     else
       notify ":warning: Config backup failed — push error. Manual intervention may be required."
       echo "Backup failed: push error"


### PR DESCRIPTION
## Summary

- `git_backup.sh` now pushes to `ha-backup` instead of `main` — `main` is branch-protected (locked + PR required), so direct pushes were being silently rejected
- After a successful push, the script opens a PR from `ha-backup` → `main` via the GitHub API, or surfaces the existing open PR in Slack if one already exists
- Adds `/config/.github_token` to `.gitignore` — a GitHub PAT with `repo` scope stored there enables PR creation

## One-time setup on the HA instance

```bash
echo "ghp_your_token_here" > /config/.github_token
chmod 600 /config/.github_token
```

## Slack notifications

| Scenario | Message |
|---|---|
| New PR opened | `:arrow_up: Config backup PR opened: <url>` |
| PR already open | `:floppy_disk: Config backed up. PR already open: <url>` |
| No token found | `:floppy_disk: Config backed up. Add a token to enable PR creation` |
| Push failed | `:warning: Config backup failed — push error` |
| Rebase conflict | `:warning: Config backup failed — rebase conflict` |

## Test plan

- [ ] Add `/config/.github_token` on the HA instance
- [ ] Trigger the backup automation and verify push goes to `ha-backup` branch
- [ ] Verify PR is opened to `main` and linked in Slack
- [ ] Trigger a second backup and verify "PR already open" message fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)