### PR TITLE
Fix race condition between entity list write and git commit

### DIFF
--- a/automations/backup.yaml
+++ b/automations/backup.yaml
@@ -8,7 +8,6 @@
     event: start
   actions:
   - sequence:
-    - action: shell_command.write_entity_list
     - action: hassio.addon_stdin
       data:
         addon: core_ssh

--- a/git_backup.sh
+++ b/git_backup.sh
@@ -91,6 +91,7 @@ GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE")
 GIT_AUTH=(-c "credential.helper=!f() { echo username=oauth2; echo password=${GITHUB_TOKEN}; }; f")
 
 cd /config
+bash /config/write_entity_list.sh
 git add .
 
 if ! git diff-index --quiet HEAD -- 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Moves `write_entity_list.sh` into `git_backup.sh` so it runs synchronously before `git add .`
- Removes the separate `shell_command.write_entity_list` step from the backup automation
- Eliminates the async timing gap caused by `hassio.addon_stdin` being fire-and-forget

## Test plan
- [ ] Trigger the backup automation manually and verify `entity_list.txt` is included in the commit
- [ ] Confirm no errors in HA logs from the backup run

🤖 Generated with [Claude Code](https://claude.com/claude-code)