### PR TITLE
Replace python3 with jq in write_entity_list.sh

### DIFF
--- a/write_entity_list.sh
+++ b/write_entity_list.sh
@@ -2,27 +2,20 @@
 # Writes a list of opted-in entities to entity_list.txt.
 # To include an entity, apply the "entity_list" label to it in
 # Settings > Labels, then tag the entity via its settings page.
-python3 -c "
-import json, sys
 
-registry = '/config/.storage/core.entity_registry'
-try:
-    with open(registry) as f:
-        data = json.load(f)
-except FileNotFoundError:
-    print(f'ERROR: {registry} not found', file=sys.stderr)
-    sys.exit(1)
-except json.JSONDecodeError as e:
-    print(f'ERROR: could not parse {registry}: {e}', file=sys.stderr)
-    sys.exit(1)
+REGISTRY="/config/.storage/core.entity_registry"
 
-entities = sorted(
-    (e for e in data['data']['entities'] if 'entity_list' in e.get('labels', [])),
-    key=lambda e: e['entity_id']
-)
-with open('/config/entity_list.txt', 'w') as out:
-    for e in entities:
-        name = e.get('name') or e.get('original_name', '')
-        out.write(f\"{e['entity_id']} | {name}\n\")
-print(f'Wrote {len(entities)} entities to entity_list.txt')
-"
+if [ ! -f "$REGISTRY" ]; then
+  echo "ERROR: $REGISTRY not found" >&2
+  exit 1
+fi
+
+count=$(jq -r '
+  .data.entities
+  | map(select(.labels | index("entity_list")))
+  | sort_by(.entity_id)
+  | .[]
+  | "\(.entity_id) | \(.name // .original_name // "")"
+' "$REGISTRY" | tee /config/entity_list.txt | wc -l)
+
+echo "Wrote ${count} entities to entity_list.txt"


### PR DESCRIPTION
## Summary
- Rewrites `write_entity_list.sh` to use `jq` instead of `python3`
- The SSH addon doesn't have `python3` available, causing a "command not found" error
- `jq` is already a dependency of `git_backup.sh` so it's guaranteed to be present

## Test plan
- [ ] Trigger the backup automation and verify `entity_list.txt` is written correctly
- [ ] Confirm no "command not found" errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)