### PR TITLE
Fix jq crash when entity labels is null

### DIFF
--- a/write_entity_list.sh
+++ b/write_entity_list.sh
@@ -12,7 +12,7 @@ fi
 
 count=$(jq -r '
   .data.entities
-  | map(select(.labels | index("entity_list")))
+  | map(select((.labels // []) | contains(["entity_list"])))
   | sort_by(.entity_id)
   | .[]
   | "\(.entity_id) | \(.name // .original_name // "")"


### PR DESCRIPTION
## Summary
- `index("entity_list")` fails when `.labels` is `null` (entities with no labels set) — jq throws "cannot index object with number"
- Replace with `(.labels // []) | contains(["entity_list"])` which handles null safely

## Test plan
- [ ] Trigger backup and confirm `entity_list.txt` is written without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)