### PR TITLE
Use date-stamped branch name for backups to avoid PR collisions

### DIFF
--- a/git_backup.sh
+++ b/git_backup.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Checks out ha-backup, merges main, commits changed config files, pushes,
-# and opens (or surfaces) a PR to main. Returns to main on exit.
+# Checks out a date-stamped ha-backup/YYYY-MM-DD branch, merges main,
+# commits changed config files, pushes, and opens a PR to main. Returns to main on exit.
 # Requires a GitHub PAT at /config/.github_token with repo scope to create PRs.
 
 set -euo pipefail
 
 GITHUB_TOKEN_FILE="/config/.github_token"
-BACKUP_BRANCH="ha-backup"
+BACKUP_BRANCH="ha-backup/$(date +'%Y-%m-%d')"
 
 notify() {
   local msg="$1"


### PR DESCRIPTION
## Summary
- Changes `BACKUP_BRANCH` from the static `ha-backup` to `ha-backup/YYYY-MM-DD`
- Root cause: GitHub rejects creating a new PR from a branch that already has one (open or merged), and the fallback query only finds open PRs — so any previously-merged backup PR caused silent failure
- With a daily-stamped branch, each day's backup gets a fresh branch and a fresh PR with no collision
- Multiple runs on the same day (e.g. 3am + HA restart) will push to the same day's branch and update the same PR

## Test plan
- [ ] Trigger backup and confirm a new `ha-backup/YYYY-MM-DD` branch and PR are created
- [ ] Trigger backup again same day and confirm it updates the existing PR rather than creating a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)