### PR TITLE
Add time to backup branch name and trigger backup after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,17 @@ jobs:
             -d "$body" \
             "${{ secrets.HA_URL }}/api/services/notify/make_nashville"
 
+      # --- Post-deploy backup ---
+
+      - name: Trigger config backup
+        if: success()
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"addon": "core_ssh", "input": "bash /config/git_backup.sh"}' \
+            "${{ secrets.HA_URL }}/api/services/hassio/addon_stdin"
+
       # --- Failure notification ---
 
       - name: Notify failure

--- a/git_backup.sh
+++ b/git_backup.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 GITHUB_TOKEN_FILE="/config/.github_token"
-BACKUP_BRANCH="ha-backup/$(date +'%Y-%m-%d')"
+BACKUP_BRANCH="ha-backup/$(date +'%Y-%m-%d-%H%M')"
 
 notify() {
   local msg="$1"


### PR DESCRIPTION
## Summary
- **Branch timestamp**: `ha-backup/YYYY-MM-DD` → `ha-backup/YYYY-MM-DD-HHMM` so each run gets a unique branch and PR even when triggered multiple times in a day
- **Post-deploy backup**: Added a `Trigger config backup` step at the end of the deploy workflow that fires `hassio.addon_stdin` to run `git_backup.sh` after every successful deploy — keeps the backup branch in sync with what was just deployed

## Test plan
- [ ] Merge to main and verify the backup step runs and creates a `ha-backup/YYYY-MM-DD-HHMM` branch and PR
- [ ] Confirm the step is skipped when the deploy itself fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)