### PR TITLE
Thread lifecycle notifications under Print Starting in Slack

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -57,20 +57,42 @@
       end_dt: '{% set e = as_datetime(states("sensor."+printer+"_end_time"), none)
         %}{% if e %}{{ e }}{% else %}{% set s = states("sensor."+printer+"_print_time_left")|int(0)
         %}{% if s > 0 %}{{ now() + timedelta(seconds=s) }}{% endif %}{% endif %}'
-  - data:
-      target: "#3dprint-info"
-      message: ":speech_balloon: {{ states('sensor.'+printer+'_print_progress', with_unit=True)
-        }}{% if end_dt %} | {% set secs = (as_timestamp(end_dt) - as_timestamp(now()))
-        | int(0) %}{% set h = secs // 3600 %}{% set m = (secs % 3600) // 60 %}{{ h
-        }}h {{ '%02d' | format(m) }}m (ends {{ as_timestamp(end_dt) | timestamp_custom('%I:%M
-        %p') }}){% endif %} — {% if display_name != object_name %}@{{display_name}},
-        {% endif %}{{object_name}} {% set prog = states('sensor.'+printer+'_print_progress')
-        | int(0) %}{% if prog >= 90 %}almost done!{% elif prog >= 50 %}halfway there!{%
-        else %}printing away!{% endif %} {{states('input_text.'+printer+'_stream')}}"
-      data:
-        username: '{{ printer | capitalize }}'
-        icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
-    action: notify.make_nashville
+      thread_ts: '{{ states("input_text."+printer+"_slack_thread_ts") }}'
+  - choose:
+    - conditions:
+      - condition: template
+        value_template: "{{ thread_ts != '' }}"
+      sequence:
+      - data:
+          target: "#3dprint-info"
+          message: ":speech_balloon: {{ states('sensor.'+printer+'_print_progress', with_unit=True)
+            }}{% if end_dt %} | {% set secs = (as_timestamp(end_dt) - as_timestamp(now()))
+            | int(0) %}{% set h = secs // 3600 %}{% set m = (secs % 3600) // 60 %}{{ h
+            }}h {{ '%02d' | format(m) }}m (ends {{ as_timestamp(end_dt) | timestamp_custom('%I:%M
+            %p') }}){% endif %} — {% if display_name != object_name %}@{{display_name}},
+            {% endif %}{{object_name}} {% set prog = states('sensor.'+printer+'_print_progress')
+            | int(0) %}{% if prog >= 90 %}almost done!{% elif prog >= 50 %}halfway there!{%
+            else %}printing away!{% endif %} {{states('input_text.'+printer+'_stream')}}"
+          data:
+            username: '{{ printer | capitalize }}'
+            icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+            thread_ts: '{{ thread_ts }}'
+        action: notify.make_nashville
+    default:
+    - data:
+        target: "#3dprint-info"
+        message: ":speech_balloon: {{ states('sensor.'+printer+'_print_progress', with_unit=True)
+          }}{% if end_dt %} | {% set secs = (as_timestamp(end_dt) - as_timestamp(now()))
+          | int(0) %}{% set h = secs // 3600 %}{% set m = (secs % 3600) // 60 %}{{ h
+          }}h {{ '%02d' | format(m) }}m (ends {{ as_timestamp(end_dt) | timestamp_custom('%I:%M
+          %p') }}){% endif %} — {% if display_name != object_name %}@{{display_name}},
+          {% endif %}{{object_name}} {% set prog = states('sensor.'+printer+'_print_progress')
+          | int(0) %}{% if prog >= 90 %}almost done!{% elif prog >= 50 %}halfway there!{%
+          else %}printing away!{% endif %} {{states('input_text.'+printer+'_stream')}}"
+        data:
+          username: '{{ printer | capitalize }}'
+          icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+      action: notify.make_nashville
   mode: single
 - id: '1722144402850'
   alias: Lifecycle Print Starting
@@ -114,9 +136,8 @@
         else ""}}'
       bed_type: '{{states("sensor."+printer+"_print_bed_type") if states("sensor."+printer+"_print_bed_type")
         not in ["unknown","unavailable",""] else ""}}'
-  - data:
-      target: "#3dprint-info"
-      message: ":printer: {% if print_weight %}{{print_weight}}{% endif %}{% if total_layers
+  - variables:
+      msg: ":printer: {% if print_weight %}{{print_weight}}{% endif %}{% if total_layers
         %}{% if print_weight %} | {% endif %}{{total_layers}} layers{% endif %}{% if
         end_dt %}{% if print_weight or total_layers %} | {% endif %}{% set secs = (as_timestamp(end_dt)
         - as_timestamp(now())) | int(0) %}{% set h = secs // 3600 %}{% set m = (secs
@@ -125,10 +146,18 @@
         or end_dt %} — {% endif %}{% if display_name != object_name %}@{{display_name}},
         {% endif %}{{object_name}} is underway!{% if bed_type %} on a {{bed_type}}{%
         endif %}. {{states('input_text.'+printer+'_stream')}}"
-      data:
-        username: '{{ printer | capitalize }}'
-        icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
-    action: notify.make_nashville
+  - action: rest_command.slack_post_3dprint
+    data:
+      channel: "#3dprint-info"
+      text: "{{ msg }}"
+      username: "{{ printer | capitalize }}"
+      icon_emoji: ":{{ 'kiwifruit' if printer == 'kiwi' else printer }}:"
+    response_variable: slack_response
+  - action: input_text.set_value
+    target:
+      entity_id: "input_text.{{ printer }}_slack_thread_ts"
+    data:
+      value: "{{ slack_response.content.ts | default('') }}"
   - if:
     - condition: template
       value_template: "{{ printer == 'pineapple' }}"
@@ -171,15 +200,37 @@
       used_weight: '{{states("sensor."+printer+"_used_material_weight", with_unit=True)
         if states("sensor."+printer+"_used_material_weight") not in ["unknown","unavailable"]
         else ""}}'
-  - data:
-      target: "#3dprint-info"
-      message: ":white_check_mark: {{job_time_str}}{% if used_weight %} | {{used_weight}}{% endif
-        %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
-        is done! Come grab it and clear the plate for the next maker. {{states('input_text.'+printer+'_stream')}}"
-      data:
-        username: '{{ printer | capitalize }}'
-        icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
-    action: notify.make_nashville
+      thread_ts: '{{ states("input_text."+printer+"_slack_thread_ts") }}'
+  - choose:
+    - conditions:
+      - condition: template
+        value_template: "{{ thread_ts != '' }}"
+      sequence:
+      - data:
+          target: "#3dprint-info"
+          message: ":white_check_mark: {{job_time_str}}{% if used_weight %} | {{used_weight}}{% endif
+            %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
+            is done! Come grab it and clear the plate for the next maker. {{states('input_text.'+printer+'_stream')}}"
+          data:
+            username: '{{ printer | capitalize }}'
+            icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+            thread_ts: '{{ thread_ts }}'
+        action: notify.make_nashville
+    default:
+    - data:
+        target: "#3dprint-info"
+        message: ":white_check_mark: {{job_time_str}}{% if used_weight %} | {{used_weight}}{% endif
+          %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
+          is done! Come grab it and clear the plate for the next maker. {{states('input_text.'+printer+'_stream')}}"
+        data:
+          username: '{{ printer | capitalize }}'
+          icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+      action: notify.make_nashville
+  - action: input_text.set_value
+    target:
+      entity_id: "input_text.{{ printer }}_slack_thread_ts"
+    data:
+      value: ""
   mode: parallel
   max: 4
 - id: '1722194364076'
@@ -208,15 +259,37 @@
       display_name: '{{states("sensor."+printer+"_display_name") }}'
       object_name: '{{states("sensor."+printer+"_object") }}'
       progress: '{{states("sensor."+printer+"_print_progress") | int(0)}}'
-  - data:
-      target: "#3dprint-info"
-      message: ':octagonal_sign: {{progress}}% — {% if display_name != object_name %}@{{display_name}},
-        {% endif %}{{object_name}} stopped mid-print. Come take a look and see what
-        happened. {{states(''input_text.''+printer+''_stream'')}}'
-      data:
-        username: '{{ printer | capitalize }}'
-        icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
-    action: notify.make_nashville
+      thread_ts: '{{ states("input_text."+printer+"_slack_thread_ts") }}'
+  - choose:
+    - conditions:
+      - condition: template
+        value_template: "{{ thread_ts != '' }}"
+      sequence:
+      - data:
+          target: "#3dprint-info"
+          message: ':octagonal_sign: {{progress}}% — {% if display_name != object_name %}@{{display_name}},
+            {% endif %}{{object_name}} stopped mid-print. Come take a look and see what
+            happened. {{states(''input_text.''+printer+''_stream'')}}'
+          data:
+            username: '{{ printer | capitalize }}'
+            icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+            thread_ts: '{{ thread_ts }}'
+        action: notify.make_nashville
+    default:
+    - data:
+        target: "#3dprint-info"
+        message: ':octagonal_sign: {{progress}}% — {% if display_name != object_name %}@{{display_name}},
+          {% endif %}{{object_name}} stopped mid-print. Come take a look and see what
+          happened. {{states(''input_text.''+printer+''_stream'')}}'
+        data:
+          username: '{{ printer | capitalize }}'
+          icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+      action: notify.make_nashville
+  - action: input_text.set_value
+    target:
+      entity_id: "input_text.{{ printer }}_slack_thread_ts"
+    data:
+      value: ""
   mode: parallel
   max: 4
 - id: '1740355200000'
@@ -241,15 +314,32 @@
       object_name: '{{states("sensor."+printer+"_object") }}'
       error_info: '{{states("sensor."+printer+"_print_error") if states("sensor."+printer+"_print_error")
         not in ["unknown","unavailable",""] else ""}}'
-  - data:
-      target: "#3dprint-info"
-      message: ':rotating_light: {% if error_info %}{{error_info}} — {% endif %}{% if display_name
-        != object_name %}@{{display_name}}, {% endif %}{{object_name}} hit a snag.
-        Head over and check on it. {{states(''input_text.''+printer+''_stream'')}}'
-      data:
-        username: '{{ printer | capitalize }}'
-        icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
-    action: notify.make_nashville
+      thread_ts: '{{ states("input_text."+printer+"_slack_thread_ts") }}'
+  - choose:
+    - conditions:
+      - condition: template
+        value_template: "{{ thread_ts != '' }}"
+      sequence:
+      - data:
+          target: "#3dprint-info"
+          message: ':rotating_light: {% if error_info %}{{error_info}} — {% endif %}{% if display_name
+            != object_name %}@{{display_name}}, {% endif %}{{object_name}} hit a snag.
+            Head over and check on it. {{states(''input_text.''+printer+''_stream'')}}'
+          data:
+            username: '{{ printer | capitalize }}'
+            icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+            thread_ts: '{{ thread_ts }}'
+        action: notify.make_nashville
+    default:
+    - data:
+        target: "#3dprint-info"
+        message: ':rotating_light: {% if error_info %}{{error_info}} — {% endif %}{% if display_name
+          != object_name %}@{{display_name}}, {% endif %}{{object_name}} hit a snag.
+          Head over and check on it. {{states(''input_text.''+printer+''_stream'')}}'
+        data:
+          username: '{{ printer | capitalize }}'
+          icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+      action: notify.make_nashville
   mode: parallel
   max: 4
 - id: '1740400001000'
@@ -281,18 +371,38 @@
       end_dt: '{% set e = as_datetime(states("sensor."+printer+"_end_time"), none)
         %}{% if e %}{{ e }}{% else %}{% set s = states("sensor."+printer+"_print_time_left")|int(0)
         %}{% if s > 0 %}{{ now() + timedelta(seconds=s) }}{% endif %}{% endif %}'
-  - data:
-      target: "#3dprint-info"
-      message: ':double_vertical_bar: {{progress}}%{% if end_dt %} | {% set secs =
-        (as_timestamp(end_dt) - as_timestamp(now())) | int(0) %}{% set h = secs //
-        3600 %}{% set m = (secs % 3600) // 60 %}{{ h }}h {{ ''%02d'' | format(m)
-        }}m (ends {{ as_timestamp(end_dt) | timestamp_custom(''%I:%M %p'') }}){% endif
-        %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
-        is on hold. Head over when you get a chance! {{states(''input_text.''+printer+''_stream'')}}'
-      data:
-        username: '{{ printer | capitalize }}'
-        icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
-    action: notify.make_nashville
+      thread_ts: '{{ states("input_text."+printer+"_slack_thread_ts") }}'
+  - choose:
+    - conditions:
+      - condition: template
+        value_template: "{{ thread_ts != '' }}"
+      sequence:
+      - data:
+          target: "#3dprint-info"
+          message: ':double_vertical_bar: {{progress}}%{% if end_dt %} | {% set secs =
+            (as_timestamp(end_dt) - as_timestamp(now())) | int(0) %}{% set h = secs //
+            3600 %}{% set m = (secs % 3600) // 60 %}{{ h }}h {{ ''%02d'' | format(m)
+            }}m (ends {{ as_timestamp(end_dt) | timestamp_custom(''%I:%M %p'') }}){% endif
+            %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
+            is on hold. Head over when you get a chance! {{states(''input_text.''+printer+''_stream'')}}'
+          data:
+            username: '{{ printer | capitalize }}'
+            icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+            thread_ts: '{{ thread_ts }}'
+        action: notify.make_nashville
+    default:
+    - data:
+        target: "#3dprint-info"
+        message: ':double_vertical_bar: {{progress}}%{% if end_dt %} | {% set secs =
+          (as_timestamp(end_dt) - as_timestamp(now())) | int(0) %}{% set h = secs //
+          3600 %}{% set m = (secs % 3600) // 60 %}{{ h }}h {{ ''%02d'' | format(m)
+          }}m (ends {{ as_timestamp(end_dt) | timestamp_custom(''%I:%M %p'') }}){% endif
+          %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
+          is on hold. Head over when you get a chance! {{states(''input_text.''+printer+''_stream'')}}'
+        data:
+          username: '{{ printer | capitalize }}'
+          icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+      action: notify.make_nashville
   mode: parallel
   max: 4
 - id: '1722445886802'

--- a/automations/webhooks.yaml
+++ b/automations/webhooks.yaml
@@ -60,15 +60,33 @@
       file_name: '{{ trigger.json.FileName | default("") }}'
       progress: '{{ trigger.json.Progress | default(0) }}'
       stream_url: '{{ states("input_text." + printer_id + "_stream") }}'
-  - action: notify.make_nashville
-    data:
-      target: "#3dprint-info"
-      message: '{{ progress }}% — {% if event_type == 8 %}:rotating_light: Gadget paused
-        {{ printer_name }} after detecting a failure{% else %}:warning: Gadget detected
-        a possible failure on {{ printer_name }}{% endif %}{% if file_name %} printing
-        {{ file_name }}{% endif %}. {{ stream_url }}'
+      thread_ts: '{{ states("input_text." + printer_id + "_slack_thread_ts") }}'
+  - choose:
+    - conditions:
+      - condition: template
+        value_template: "{{ thread_ts != '' }}"
+      sequence:
+      - action: notify.make_nashville
+        data:
+          target: "#3dprint-info"
+          message: '{{ progress }}% — {% if event_type == 8 %}:rotating_light: Gadget paused
+            {{ printer_name }} after detecting a failure{% else %}:warning: Gadget detected
+            a possible failure on {{ printer_name }}{% endif %}{% if file_name %} printing
+            {{ file_name }}{% endif %}. {{ stream_url }}'
+          data:
+            username: Gadget
+            icon: robot_face
+            thread_ts: '{{ thread_ts }}'
+    default:
+    - action: notify.make_nashville
       data:
-        username: Gadget
-        icon: robot_face
+        target: "#3dprint-info"
+        message: '{{ progress }}% — {% if event_type == 8 %}:rotating_light: Gadget paused
+          {{ printer_name }} after detecting a failure{% else %}:warning: Gadget detected
+          a possible failure on {{ printer_name }}{% endif %}{% if file_name %} printing
+          {{ file_name }}{% endif %}. {{ stream_url }}'
+        data:
+          username: Gadget
+          icon: robot_face
   mode: parallel
   max: 5

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -34,10 +34,39 @@ shell_command:
   git_pull: "git -C /config pull --rebase origin main"
   write_entity_list: "bash /config/write_entity_list.sh"
 
+rest_command:
+  slack_post_3dprint:
+    url: https://slack.com/api/chat.postMessage
+    method: POST
+    headers:
+      Authorization: !secret slack_bot_token_header
+      Content-Type: "application/json; charset=utf-8"
+    payload: >-
+      {"channel": {{ channel | tojson }}, "text": {{ text | tojson }},
+       "username": {{ username | tojson }}, "icon_emoji": {{ icon_emoji | tojson }}}
+
 input_text:
   pineapple_last_job:
     name: Pineapple Last Job
     max: 255
+  kiwi_slack_thread_ts:
+    name: Kiwi Slack Thread TS
+    max: 30
+  mango_slack_thread_ts:
+    name: Mango Slack Thread TS
+    max: 30
+  papaya_slack_thread_ts:
+    name: Papaya Slack Thread TS
+    max: 30
+  strawberry_slack_thread_ts:
+    name: Strawberry Slack Thread TS
+    max: 30
+  huckleberry_slack_thread_ts:
+    name: Huckleberry Slack Thread TS
+    max: 30
+  pineapple_slack_thread_ts:
+    name: Pineapple Slack Thread TS
+    max: 30
 
 input_boolean:
   facilities_pulse_verbose:


### PR DESCRIPTION
## Summary

- Adds `rest_command.slack_post_3dprint` that calls `chat.postMessage` directly, capturing the Slack `ts` for thread anchoring
- Adds 6 `input_text` helpers (`{printer}_slack_thread_ts`) to store the thread timestamp per printer
- Print Starting now posts via `rest_command` and stores the returned `ts`
- Progress, Paused, Stopped, Error, and Finished post as thread replies when a `ts` exists; fall back to channel-level if not
- Finished and Stopped clear the `ts` after posting so it doesn't bleed into the next print
- Gadget webhook follows the same threading pattern

## Manual step required

Add to `secrets.yaml` on the HA host before deploying:
```
slack_bot_token_header: "Bearer xoxb-your-token-here"
```
(Same bot token that backs `notify.make_nashville`.)

## Test plan

- [ ] Trigger a print start → Print Starting message appears in #3dprint-info as a top-level post
- [ ] Check `input_text.{printer}_slack_thread_ts` has a value in HA Dev Tools
- [ ] Wait for a progress milestone → appears as a thread reply under Print Starting
- [ ] Let print finish → Finished also appears in thread; `_slack_thread_ts` clears to `""`
- [ ] Verify Roundup still posts as a top-level message (not threaded)
- [ ] Verify Weekly Summary still posts top-level

🤖 Generated with [Claude Code](https://claude.com/claude-code)