### PR TITLE
Tolerate empty reply when restarting HA during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,8 @@ jobs:
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
             -H "Content-Type: application/json" \
-            "${{ secrets.HA_URL }}/api/services/homeassistant/restart"
+            "${{ secrets.HA_URL }}/api/services/homeassistant/restart" \
+            || [ $? -eq 52 ]
 
       # --- Reload path ---
 


### PR DESCRIPTION
## Summary
- HA drops the connection before responding when it receives a restart command, causing curl exit code 52 (empty reply from server)
- The restart itself succeeds — curl just can't get a response back before HA shuts down
- This tolerates exit code 52 specifically while still failing on real errors (bad auth, unreachable host, etc.)

## Test plan
- [ ] Merge and confirm the deploy workflow succeeds when `configuration.yaml` changes trigger a restart
- [ ] Verify `#deployment-feed` no longer gets a failure notification for restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)