### PR TITLE
Validate Slack thread_ts before using it

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -61,7 +61,7 @@
   - choose:
     - conditions:
       - condition: template
-        value_template: "{{ thread_ts != '' }}"
+        value_template: "{{ '.' in thread_ts }}"
       sequence:
       - data:
           target: "#3dprint-info"
@@ -157,7 +157,7 @@
     target:
       entity_id: "input_text.{{ printer }}_slack_thread_ts"
     data:
-      value: "{{ slack_response.content.ts | default('') }}"
+      value: "{% set ts = slack_response.content.ts | default('') | string %}{{ ts if '.' in ts else '' }}"
   - if:
     - condition: template
       value_template: "{{ printer == 'pineapple' }}"
@@ -204,7 +204,7 @@
   - choose:
     - conditions:
       - condition: template
-        value_template: "{{ thread_ts != '' }}"
+        value_template: "{{ '.' in thread_ts }}"
       sequence:
       - data:
           target: "#3dprint-info"
@@ -263,7 +263,7 @@
   - choose:
     - conditions:
       - condition: template
-        value_template: "{{ thread_ts != '' }}"
+        value_template: "{{ '.' in thread_ts }}"
       sequence:
       - data:
           target: "#3dprint-info"
@@ -318,7 +318,7 @@
   - choose:
     - conditions:
       - condition: template
-        value_template: "{{ thread_ts != '' }}"
+        value_template: "{{ '.' in thread_ts }}"
       sequence:
       - data:
           target: "#3dprint-info"
@@ -375,7 +375,7 @@
   - choose:
     - conditions:
       - condition: template
-        value_template: "{{ thread_ts != '' }}"
+        value_template: "{{ '.' in thread_ts }}"
       sequence:
       - data:
           target: "#3dprint-info"

--- a/automations/webhooks.yaml
+++ b/automations/webhooks.yaml
@@ -64,7 +64,7 @@
   - choose:
     - conditions:
       - condition: template
-        value_template: "{{ thread_ts != '' }}"
+        value_template: "{{ '.' in thread_ts }}"
       sequence:
       - action: notify.make_nashville
         data:


### PR DESCRIPTION
## Summary
- Slack was rejecting `thread_ts: "0"` with "0 is not a valid thread ts"
- Changed all 6 guard conditions from `thread_ts != ''` to `'.' in thread_ts` — valid Slack timestamps always contain a dot (e.g. `1234567890.123456`), so this catches `""`, `"0"`, `"unknown"`, `"unavailable"`, etc.
- Also hardened the storage step in Print Starting to only save the ts if it contains a dot, preventing bad values from being persisted

## Test plan
- [ ] Start a print and confirm the Print Starting notification posts and threads correctly
- [ ] Confirm progress/finished/stopped/error notifications thread under the starting message
- [ ] Verify no "0 is not a valid thread ts" errors in HA logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)