### PR TITLE
Implement updated power outage and restoration alerts

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -35,6 +35,17 @@
       minutes: 5
   - trigger: state
     entity_id: sensor.total_power_alarm_power_failure_alarm
+    to: "Alert"
+    for:
+      seconds: 5
+    id: power_out
+
+  - trigger: state
+    entity_id: sensor.total_power_alarm_power_failure_alarm
+    to: "Normal"
+    for:
+      seconds: 10
+    id: power_restored
   - trigger: state
     entity_id: binary_sensor.water_leak_sensor
   conditions:
@@ -42,49 +53,83 @@
     value_template: >
       {{ (this.attributes.last_triggered is none or
           (now() - this.attributes.last_triggered).total_seconds() > 900)
-         and (trigger.platform == 'numeric_state' or
-              trigger.entity_id in ['sensor.total_power_alarm_power_failure_alarm', 'binary_sensor.water_leak_sensor'] or
-              (trigger.from_state.state | float(0) - trigger.to_state.state | float(0)) | abs > 5) }}
+         and (
+             trigger.platform == 'numeric_state'
+             or trigger.id in ['power_out', 'power_restored']
+             or trigger.entity_id in ['binary_sensor.water_leak_sensor']
+             or (((trigger.from_state.state | float(0)) - (trigger.to_state.state | float(0))) | abs) > 5
+             ) }}
   actions:
-  - action: notify.make_nashville
-    data:
-      target: "#facilities-feed"
+  - choose:
+    - conditions:
+        - condition: trigger
+          id: power_out
+      sequence:
+        - action: notify.make_nashville
+          data:
+            target: "#facilities-feed"
+            data:
+              icon: warning
+              username: Facilities Pulse
+            message: >-
+              :rotating_light: *POWER OUTAGE*
+              State: {{ trigger.to_state.state }}
+              *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
+
+    - conditions:
+        - condition: trigger
+          id: power_restored
+      sequence:
+        - action: notify.make_nashville
+          data:
+            target: "#facilities-feed"
+            data:
+              icon: white_check_mark
+              username: Facilities Pulse
+            message: >-
+              :white_check_mark: *Power Restored*
+              State: {{ trigger.to_state.state }}
+              *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
+  default:
+    - action: notify.make_nashville
       data:
-        icon: warning
-        username: Facilities Pulse
-      message: |
-        :warning: *Facilities Alert* — {{ trigger.to_state.name }} {{ trigger.to_state.state }}{{ trigger.to_state.attributes.unit_of_measurement | default('') }}
-        *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
-
-        *:thermometer: Environment*
-        {% set ns = namespace(count=0) -%}
-        {% for device_id in label_devices('facilities_pulse') -%}
-        {% set entities = device_entities(device_id) -%}
-        {% set temp_e = entities | reject('search','display_temperature') | select('search','temperature') | first | default(none) -%}
-        {% set hum_e  = entities | select('search','humidity') | first | default(none) -%}
-        {% if temp_e and states(temp_e) not in ['unknown','unavailable',none] -%}
-        {% set ns.count = ns.count + 1 -%}
-        {% set t = states(temp_e) | float(0) -%}
-        {% set icon = ':green_circle:' if t >= 65 and t <= 80 else ':yellow_circle:' if t >= 60 and t < 65 or t > 80 and t <= 85 else ':red_circle:' -%}
-        {{ icon }} {{ "%.1f°F"|format(t) }}  {{ "%-17s"|format(area_name(temp_e)|default('Unknown')) }} {{ states(hum_e)|float(0)|round(0)|int }}%
-        {% endif -%}
-        {% endfor -%}
-        {% if ns.count == 0 %}:warning: No sensors found — check the facilities_pulse label{% endif -%}
-        :partly_sunny: {{ "%.1f°F"|format(state_attr('weather.forecast_home','temperature')|float(0)) }}  {{ "%-17s"|format('Outside') }} {{ state_attr('weather.forecast_home','humidity')|int }}%
-
-        *:gear: Systems*
-        {% set pwr = states('sensor.total_power_alarm_power_failure_alarm') | lower -%}
-        {{ ':green_circle:' if pwr == 'ok' else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
-        {% set leak = states('binary_sensor.water_leak_sensor') -%}
-        {{ ':green_circle:' if leak == 'off' else ':red_circle:' }} {{ "%-14s"|format(state_translated('binary_sensor.water_leak_sensor')) }}  Exec Bathroom
-        {% set kpsi = states('sensor.kaeser_monitor_system_pressure') | float(0) -%}
-        {{ ':green_circle:' if kpsi >= 80 else ':red_circle:' }} {{ "%-14s"|format(kpsi | round(1) | string ~ ' psi') }}  Kaeser
-
-        *:dash: 3D Print Room*
-        {% set aq = states('sensor.air_quality_overall_status') -%}
-        {% set aq_icon = ':green_circle:' if aq == 'Good' else ':yellow_circle:' if aq == 'Moderate' else ':large_orange_circle:' if aq == 'Poor' else ':red_circle:' -%}
-        {{ aq_icon }} Air Quality: {{ aq }}
-        CO₂: {{ states('sensor.air_quality_carbon_dioxide') }} ppm  |  VOC: {{ states('sensor.air_quality_voc_index') }}  |  PM2.5: {{ states('sensor.air_quality_pm2_5') | float(0) | round(1) }} ug/m3
+        target: "#facilities-feed"
+        data:
+          icon: warning
+          username: Facilities Pulse
+        message: |
+          :warning: *Facilities Alert* — {{ trigger.to_state.name }} {{ trigger.to_state.state }}{{ trigger.to_state.attributes.unit_of_measurement | default('') }}
+          *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
+  
+          *:thermometer: Environment*
+          {% set ns = namespace(count=0) -%}
+          {% for device_id in label_devices('facilities_pulse') -%}
+          {% set entities = device_entities(device_id) -%}
+          {% set temp_e = entities | reject('search','display_temperature') | select('search','temperature') | first | default(none) -%}
+          {% set hum_e  = entities | select('search','humidity') | first | default(none) -%}
+          {% if temp_e and states(temp_e) not in ['unknown','unavailable',none] -%}
+          {% set ns.count = ns.count + 1 -%}
+          {% set t = states(temp_e) | float(0) -%}
+          {% set icon = ':green_circle:' if t >= 65 and t <= 80 else ':yellow_circle:' if t >= 60 and t < 65 or t > 80 and t <= 85 else ':red_circle:' -%}
+          {{ icon }} {{ "%.1f°F"|format(t) }}  {{ "%-17s"|format(area_name(temp_e)|default('Unknown')) }} {{ states(hum_e)|float(0)|round(0)|int }}%
+          {% endif -%}
+          {% endfor -%}
+          {% if ns.count == 0 %}:warning: No sensors found — check the facilities_pulse label{% endif -%}
+          :partly_sunny: {{ "%.1f°F"|format(state_attr('weather.forecast_home','temperature')|float(0)) }}  {{ "%-17s"|format('Outside') }} {{ state_attr('weather.forecast_home','humidity')|int }}%
+  
+          *:gear: Systems*
+          {% set pwr = states('sensor.total_power_alarm_power_failure_alarm') | lower -%}
+          {{ ':green_circle:' if pwr == 'ok' else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
+          {% set leak = states('binary_sensor.water_leak_sensor') -%}
+          {{ ':green_circle:' if leak == 'off' else ':red_circle:' }} {{ "%-14s"|format(state_translated('binary_sensor.water_leak_sensor')) }}  Exec Bathroom
+          {% set kpsi = states('sensor.kaeser_monitor_system_pressure') | float(0) -%}
+          {{ ':green_circle:' if kpsi >= 80 else ':red_circle:' }} {{ "%-14s"|format(kpsi | round(1) | string ~ ' psi') }}  Kaeser
+  
+          *:dash: 3D Print Room*
+          {% set aq = states('sensor.air_quality_overall_status') -%}
+          {% set aq_icon = ':green_circle:' if aq == 'Good' else ':yellow_circle:' if aq == 'Moderate' else ':large_orange_circle:' if aq == 'Poor' else ':red_circle:' -%}
+          {{ aq_icon }} Air Quality: {{ aq }}
+          CO₂: {{ states('sensor.air_quality_carbon_dioxide') }} ppm  |  VOC: {{ states('sensor.air_quality_voc_index') }}  |  PM2.5: {{ states('sensor.air_quality_pm2_5') | float(0) | round(1) }} ug/m3
   mode: queued
   max: 2
 - id: facilities_pulse_verbose


### PR DESCRIPTION
Added triggers for power outage and restoration alerts with notifications. And added a choose block in actions for power out and restored and made the original action the default action. This will give the power alerts their own dedicated and immediate slack posts. Also, ignored the unneeded states that are not Alert or Normal power states.