### PR TITLE
Update temperature threshold from 85 to 90

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -18,7 +18,7 @@
     - sensor.woodshop_climate_sensor_temperature
     - sensor.front_hallway_climate_sensor_temperature
     - sensor.network_closet_climate_sensor_temperature
-    above: 85
+    above: 90
     for:
       minutes: 5
   - trigger: state


### PR DESCRIPTION
for temperature monitors, upped the alert from 85 degrees to 90 degrees to keep the noise down for spring. In summer we will hit 97-100+ degrees in wood shop again, so alerts will need further adjustment up. Validated YAML during pull. 