### PR TITLE
Improve trigger conditions for temperature state changes 

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -22,6 +22,7 @@
     for:
       minutes: 5
   - trigger: state
+    id: temp_state_change
     entity_id:
     - sensor.air_quality_temperature
     - sensor.ceramics_climate_sensor_temperature
@@ -40,11 +41,29 @@
   conditions:
   - condition: template
     value_template: >
-      {{ (this.attributes.last_triggered is none or
-          (now() - this.attributes.last_triggered).total_seconds() > 900)
-         and (trigger.platform == 'numeric_state' or
-              trigger.entity_id in ['sensor.total_power_alarm_power_failure_alarm', 'binary_sensor.water_leak_sensor'] or
-              (trigger.from_state.state | float(0) - trigger.to_state.state | float(0)) | abs > 5) }}
+      {% set cooldown_ok = (
+        this.attributes.last_triggered is none or
+        (now() - this.attributes.last_triggered).total_seconds() > 900
+      ) %}
+
+      {% set valid_temp_change = (
+        trigger.id == 'temp_state_change' and
+        trigger.from_state is not none and
+        trigger.to_state is not none and
+        trigger.from_state.state not in ['unknown', 'unavailable', none] and
+        trigger.to_state.state not in ['unknown', 'unavailable', none] and
+        ((trigger.from_state.state | float(0)) - (trigger.to_state.state | float(0))) | abs > 5
+      ) %}
+
+      {% set allowed_non_temp = (
+        trigger.platform == 'numeric_state' or
+        trigger.entity_id in [
+          'sensor.total_power_alarm_power_failure_alarm',
+          'binary_sensor.water_leak_sensor'
+        ]
+      ) %}
+
+      {{ cooldown_ok and (allowed_non_temp or valid_temp_change) }}
   actions:
   - action: notify.make_nashville
     data:


### PR DESCRIPTION
Refactor conditions for trigger handling in facilities.yaml to ignore unavailable or unknown state changes. This will reduce noisy alerts to Slack. 

What this does-

For the temperature sensor state trigger, it now only alerts when:
	•	both old and new values exist
	•	neither value is unknown or unavailable
	•	the temperature changed by more than 5
	•	the 15-minute cooldown has passed

So these will be ignored:
	•	71.2 → unavailable
	•	unavailable → 72.0
	•	unknown → 70.5

But this will still alert:
	•	71.0 → 77.2