### PR TITLE
Fix power status to check for Normal instead of Ok

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -93,7 +93,7 @@
 
         *:gear: Systems*
         {% set pwr = states('sensor.total_power_alarm_power_failure_alarm') | lower -%}
-        {{ ':green_circle:' if pwr == 'ok' else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
+        {{ ':green_circle:' if pwr == 'normal' else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
         {% set leak = states('binary_sensor.water_leak_sensor') -%}
         {{ ':green_circle:' if leak == 'off' else ':red_circle:' }} {{ "%-14s"|format(state_translated('binary_sensor.water_leak_sensor')) }}  Exec Bathroom
         {% set kpsi = states('sensor.kaeser_monitor_system_pressure') | float(0) -%}
@@ -142,7 +142,7 @@
 
         *:gear: Systems*
         {% set pwr = states('sensor.total_power_alarm_power_failure_alarm') | lower -%}
-        {{ ':green_circle:' if pwr == 'ok' else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
+        {{ ':green_circle:' if pwr == 'normal' else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
         {% set leak = states('binary_sensor.water_leak_sensor') -%}
         {{ ':green_circle:' if leak == 'off' else ':red_circle:' }} {{ "%-14s"|format(state_translated('binary_sensor.water_leak_sensor')) }}  Exec Bathroom
         {% set kpsi = states('sensor.kaeser_monitor_system_pressure') | float(0) -%}

--- a/dashboards/facilities.yaml
+++ b/dashboards/facilities.yaml
@@ -23,7 +23,7 @@ views:
           ## 🏢 Facilities — **{{ now().strftime('%-I:%M %p') }}**
 
           Temp range: **{{ t_min | round(1) if t_min is not none else 'N/A' }}–{{ t_max | round(1) if t_max is not none else 'N/A' }}°F** |
-          Power: **{{ 'OK' if pwr == 'ok' else '⚠️ ALARM' }}** |
+          Power: **{{ 'OK' if pwr == 'normal' else '⚠️ ALARM' }}** |
           Water: **{{ 'OK' if leak == 'off' else '⚠️ LEAK' }}** |
           Air Quality: **{{ aq }}**
 


### PR DESCRIPTION
## Summary
- The power alarm sensor (`sensor.total_power_alarm_power_failure_alarm`) reports `Normal` as its healthy state, not `Ok`
- All three power status checks were comparing against `ok`, so the green indicator never showed — it always displayed as alarm/red
- Fixed in the facilities dashboard header, Smart Alert Slack message, and Verbose Slack message

## Test plan
- [ ] Verify the facilities dashboard shows "Power: OK" when power is normal
- [ ] Trigger a verbose pulse and confirm power shows green circle
- [ ] Confirm alarm state still shows red circle / warning correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)