### PR TITLE
Fix Slack threading for printer lifecycle messages

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -157,7 +157,7 @@
     target:
       entity_id: "input_text.{{ printer }}_slack_thread_ts"
     data:
-      value: "{% set ts = slack_response.content.ts | default('') | string %}{{ ts if '.' in ts else '' }}"
+      value: "{% set ts = (slack_response.content | from_json).ts | default('') | string %}{{ ts if '.' in ts else '' }}"
   - if:
     - condition: template
       value_template: "{{ printer == 'pineapple' }}"


### PR DESCRIPTION
## Summary
- `rest_command` returns `content` as a raw JSON string, not a parsed dict
- `slack_response.content.ts` silently failed, so `thread_ts` was always empty
- Added `| from_json` to parse the response before accessing `.ts`

## Test plan
- [ ] Start a print and verify the initial message posts to `#3dprint-info`
- [ ] Verify progress/finished/stopped/error messages thread under the initial message
- [ ] Confirm `input_text.<printer>_slack_thread_ts` contains a valid timestamp after print starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)