### PR TITLE
Rename facilities pulse sections and fix spacing

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -75,7 +75,7 @@
         :warning: *Facilities Alert* — {{ trigger.to_state.name }} {{ trigger.to_state.state }}{{ trigger.to_state.attributes.unit_of_measurement | default('') }}
         *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
 
-        *:thermometer: Environment*
+        *:thermometer: Climate*
         {% set ns = namespace(count=0, unavail=[]) -%}
         {% for device_id in label_devices('facilities_pulse') -%}
         {% set entities = device_entities(device_id) -%}
@@ -112,13 +112,13 @@
         {{ ':green_circle:' if kpsi >= 80 else ':red_circle:' }} {{ "%-14s"|format(kpsi | round(1) | string ~ ' psi') }}  Kaeser
         {% else -%}
         {% set ns.unavail = ns.unavail + ['Kaeser'] -%}
-        {% endif -%}
+        {% endif %}
 
-        *:dash: 3D Print Room*
+        *:dash: Air Quality*
         {% set aq = states('sensor.air_quality_overall_status') -%}
         {% if aq not in ['unknown','unavailable'] -%}
         {% set aq_icon = ':green_circle:' if aq == 'Good' else ':yellow_circle:' if aq == 'Moderate' else ':large_orange_circle:' if aq == 'Poor' else ':red_circle:' -%}
-        {{ aq_icon }} Air Quality: {{ aq }}
+        {{ aq_icon }} 3D Printing: {{ aq }}
         CO₂: {{ states('sensor.air_quality_carbon_dioxide') }} ppm  |  VOC: {{ states('sensor.air_quality_voc_index') }}  |  PM2.5: {{ states('sensor.air_quality_pm2_5') | float(0) | round(1) }} ug/m3
         {% else -%}
         {% set ns.unavail = ns.unavail + ['Air Quality'] -%}
@@ -148,7 +148,7 @@
       message: |
         *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
 
-        *:thermometer: Environment*
+        *:thermometer: Climate*
         {% set ns = namespace(count=0, unavail=[]) -%}
         {% for device_id in label_devices('facilities_pulse') -%}
         {% set entities = device_entities(device_id) -%}
@@ -185,13 +185,13 @@
         {{ ':green_circle:' if kpsi >= 80 else ':red_circle:' }} {{ "%-14s"|format(kpsi | round(1) | string ~ ' psi') }}  Kaeser
         {% else -%}
         {% set ns.unavail = ns.unavail + ['Kaeser'] -%}
-        {% endif -%}
+        {% endif %}
 
-        *:dash: 3D Print Room*
+        *:dash: Air Quality*
         {% set aq = states('sensor.air_quality_overall_status') -%}
         {% if aq not in ['unknown','unavailable'] -%}
         {% set aq_icon = ':green_circle:' if aq == 'Good' else ':yellow_circle:' if aq == 'Moderate' else ':large_orange_circle:' if aq == 'Poor' else ':red_circle:' -%}
-        {{ aq_icon }} Air Quality: {{ aq }}
+        {{ aq_icon }} 3D Printing: {{ aq }}
         CO₂: {{ states('sensor.air_quality_carbon_dioxide') }} ppm  |  VOC: {{ states('sensor.air_quality_voc_index') }}  |  PM2.5: {{ states('sensor.air_quality_pm2_5') | float(0) | round(1) }} ug/m3
         {% else -%}
         {% set ns.unavail = ns.unavail + ['Air Quality'] -%}


### PR DESCRIPTION
## Summary
- Rename "Environment" to "Climate"
- Rename "3D Print Room" to "Air Quality"
- Rename status line from "Air Quality: Good" to "3D Printing: Good" to avoid redundancy
- Fix `-%}` whitespace stripping that was eating the blank line above the Air Quality section

Applied to both Smart Alert and Verbose automations.

## Test plan
- [ ] Trigger a facilities pulse alert and verify section names render correctly
- [ ] Confirm blank line appears between Systems and Air Quality sections
- [ ] Enable verbose mode and verify the same formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)