### PR TITLE
Disable offline notification for Pineapple

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -483,7 +483,12 @@
 - id: '1740500000001'
   alias: Lifecycle Printer Offline
   triggers:
-  - entity_id: *all_printers
+  - entity_id:
+    - sensor.mango_print_status
+    - sensor.kiwi_print_status
+    - sensor.strawberry_print_status
+    - sensor.papaya_print_status
+    - sensor.huckleberry_print_status
     to:
     - unavailable
     for:


### PR DESCRIPTION
## Summary
- Remove Pineapple from the Lifecycle Printer Offline trigger to stop noisy offline alerts
- Replaces the `*all_printers` anchor with an explicit list of the 5 remaining printers
- Other lifecycle automations (error, multi-printer offline) still include Pineapple

## Test plan
- [ ] Verify YAML validation passes in CI
- [ ] Confirm other printer offline notifications still fire
- [ ] Confirm Pineapple still triggers error and multi-printer offline automations

🤖 Generated with [Claude Code](https://claude.com/claude-code)