### PR TITLE
Fix stop-print notification showing unavailable sensor values

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -256,8 +256,8 @@
   actions:
   - variables:
       printer: '{{trigger.entity_id.split(''_'')[0].split(''.'')[1]}}'
-      display_name: '{{states("sensor."+printer+"_display_name") }}'
-      object_name: '{{states("sensor."+printer+"_object") }}'
+      display_name: '{{states("sensor."+printer+"_last_display_name") }}'
+      object_name: '{{states("sensor."+printer+"_last_object") }}'
       progress: '{{states("sensor."+printer+"_print_progress") | int(0)}}'
       thread_ts: '{{ states("input_text."+printer+"_slack_thread_ts") }}'
   - choose:


### PR DESCRIPTION
## Summary
- Switched the Print Stopped automation from live sensors (`_display_name`, `_object`) to persisted sensors (`_last_display_name`, `_last_object`)
- The live sensors go `unavailable` during the 10-second `for:` delay, causing the notification to show "0% — unavailable stopped mid-print"
- The `_last_` sensors retain their values after the printer stops, matching how the Print Finished automation already works

## Test plan
- [ ] Stop a print mid-job and verify the Slack notification shows the correct print name and user instead of "unavailable"

🤖 Generated with [Claude Code](https://claude.com/claude-code)