### PR TITLE
Add expand=event to Eventbrite attendees API call

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -122,7 +122,7 @@ recorder:
 
 rest:
   - resource_template: >-
-      https://www.eventbriteapi.com/v3/organizations/{{ states('input_text.eventbrite_org_id') }}/attendees/?changed_since={{ (now() - timedelta(days=1)).strftime('%Y-%m-%dT00:00:00Z') }}
+      https://www.eventbriteapi.com/v3/organizations/{{ states('input_text.eventbrite_org_id') }}/attendees/?changed_since={{ (now() - timedelta(days=1)).strftime('%Y-%m-%dT00:00:00Z') }}&expand=event
     headers:
       Authorization: !secret eventbrite_token_header
     scan_interval: 3600


### PR DESCRIPTION
## Summary
- Adds `expand=event` query param to the Eventbrite attendees REST sensor URL
- Without this, attendee objects only include `event_id`, not the nested event details needed for the daily digest message (`a.event.name.text`)

## Test plan
- [ ] Verify YAML validation passes in CI
- [ ] Force-update `sensor.eventbrite_daily_signups` and confirm attendee objects now include event details

🤖 Generated with [Claude Code](https://claude.com/claude-code)