### PR TITLE
Add HA config check to CI

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,8 +1,6 @@
 # Loads default set of integrations. Do not remove.
 default_config:
 
-this_is_not_a_real_integration:
-
 # Load frontend themes from the themes folder
 frontend:
   themes: !include_dir_merge_named themes


### PR DESCRIPTION
## Summary
- Adds a `check-config` job to the validate-yaml workflow
- Uses `frenck/action-home-assistant` to spin up an HA Docker container and run the built-in config checker
- Creates a dummy `secrets.yaml` in CI with placeholder values for all referenced secrets
- Catches template errors, invalid automation structure, and bad service calls on PRs — before merge

Runs in parallel with the existing YAML syntax check.

## Test plan
- [ ] Verify both `validate` and `check-config` jobs pass on this PR
- [ ] Intentionally break a template in a test branch and confirm `check-config` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)