### PR TITLE
Fix Eventbrite channel name, digest format, and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Home Assistant configuration for the [MakeNashville](https://makenashville.org) 
 - 3D printer lifecycle notifications (6 printers → `#3dprint-info` Slack)
 - Facilities monitoring: temperature, water, power, Kaeser compressor (→ `#facilities-feed`)
 - Air quality alerting for the 3D print room
+- Eventbrite event + signup notifications (→ `#integrations_sandbox`)
 - Automated nightly config backup to GitHub
 
 ---
@@ -22,6 +23,7 @@ Home Assistant configuration for the [MakeNashville](https://makenashville.org) 
 | `automations/printers.yaml` | All 3D printer automations |
 | `automations/facilities.yaml` | Facilities Pulse smart alert + verbose mode + Air Quality Alert |
 | `automations/kaeser.yaml` | Kaeser compressor overpressure alert + history purge |
+| `automations/eventbrite.yaml` | Eventbrite new event + daily signup digest notifications |
 | `automations/webhooks.yaml` | Stripe filament webhook + OctoEverywhere Gadget webhook |
 | `automations/backup.yaml` | Triggers nightly backup via SSH addon |
 | `git_backup.sh` | Backup script: checkouts ha-backup, merges main, commits, pushes, opens PR |
@@ -43,6 +45,7 @@ feature branch → PR → validate-yaml.yml passes → merge to main → deploy.
 - Always branch off `main`, open a PR, wait for YAML validation, then merge
 - On merge, `deploy.yml` pulls config onto HA, validates it, and reloads or restarts as needed
 - Deployment status posts to `#deployment-feed`
+- New integrations should post to `#integrations_sandbox` first for testing before moving to a production channel
 
 ### Backup branch
 

--- a/automations/eventbrite.yaml
+++ b/automations/eventbrite.yaml
@@ -36,7 +36,7 @@
           {{ tickets | join(', ') if tickets else 'Free' }}
     - action: notify.make_nashville
       data:
-        target: "#integration_sandbox"
+        target: "#integrations_sandbox"
         message: >-
           :calendar: *New Event Published*
           *{{ event_name }}*
@@ -64,16 +64,22 @@
         attendees: "{{ state_attr('sensor.eventbrite_daily_signups', 'attendees') }}"
         count: "{{ states('sensor.eventbrite_daily_signups') | int(0) }}"
     - variables:
-        attendee_lines: >-
+        event_lines: >-
+          {% set ns = namespace(events={}) %}
           {% for a in attendees %}
-          - {{ a.profile.name }} — _{{ a.event.name.text }}_
+            {% set ename = a.event.name.text %}
+            {% set names = ns.events.get(ename, []) + [a.profile.name] %}
+            {% set ns.events = dict(ns.events, **{ename: names}) %}
+          {% endfor %}
+          {% for event, names in ns.events.items() %}
+          - *{{ event }}* — {{ names | join(', ') }}
           {% endfor %}
     - action: notify.make_nashville
       data:
-        target: "#integration_sandbox"
+        target: "#integrations_sandbox"
         message: >-
           :wave: *Eventbrite Signups Yesterday* ({{ count }} new)
-          {{ attendee_lines }}
+          {{ event_lines }}
         data:
           username: Eventbrite
           icon: calendar


### PR DESCRIPTION
## Summary
- Fix Slack channel from `#integration_sandbox` to `#integrations_sandbox` (plural)
- Change digest format to group by event: `*Event Name* — Attendee1, Attendee2`
- Add `#integrations_sandbox` guidance to CLAUDE.md (new integrations should start here)
- Add `automations/eventbrite.yaml` to key files table in CLAUDE.md

## Test plan
- [ ] Verify YAML validation passes
- [ ] Manually trigger digest and confirm new format
- [ ] Verify messages post to `#integrations_sandbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)