### PR TITLE
Use literal block style for digest newlines

### DIFF
--- a/automations/eventbrite.yaml
+++ b/automations/eventbrite.yaml
@@ -64,7 +64,7 @@
         attendees: "{{ state_attr('sensor.eventbrite_daily_signups', 'attendees') }}"
         count: "{{ states('sensor.eventbrite_daily_signups') | int(0) }}"
     - variables:
-        event_lines: >-
+        event_lines: |-
           {% set ns = namespace(events={}) %}
           {% for a in attendees %}
             {% set ename = a.event.name.text %}
@@ -72,12 +72,12 @@
             {% set ns.events = dict(ns.events, **{ename: names}) %}
           {% endfor %}
           {% for event, names in ns.events.items() %}
-          - *{{ event }}* — {{ names | join(', ') }}
+          *{{ event }}* — {{ names | join(', ') }}
           {% endfor %}
     - action: notify.make_nashville
       data:
         target: "#integrations_sandbox"
-        message: >-
+        message: |-
           :wave: *Eventbrite Signups Yesterday* ({{ count }} new)
           {{ event_lines }}
         data:


### PR DESCRIPTION
## Summary
- Change `>-` (folded) to `|-` (literal) in digest template so each event renders on its own line in Slack

## Test plan
- [ ] Verify YAML validation passes
- [ ] Trigger digest and confirm each event appears on a separate line

🤖 Generated with [Claude Code](https://claude.com/claude-code)