### PR TITLE
Add Slack cancel button to Bambu printer notifications

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -63,6 +63,7 @@ jobs:
           eventbrite_webhook_id: "dummy-webhook-id"
           stripe_webhook_id: "dummy-stripe-webhook"
           octoeverywhere_webhook_id: "dummy-octoeverywhere-webhook"
+          slack_cancel_print_webhook_id: "dummy-cancel-webhook"
           EOF
           mkdir -p www/snapshots
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Home Assistant configuration for the [MakeNashville](https://makenashville.org) 
 | `automations/facilities.yaml` | Facilities Pulse smart alert + verbose mode + Air Quality Alert |
 | `automations/kaeser.yaml` | Kaeser compressor overpressure alert + history purge |
 | `automations/eventbrite.yaml` | Eventbrite new event + daily signup digest notifications |
-| `automations/webhooks.yaml` | Stripe filament webhook + OctoEverywhere Gadget webhook |
+| `automations/webhooks.yaml` | Stripe filament webhook + OctoEverywhere Gadget webhook + Slack cancel-print webhook |
 | `automations/backup.yaml` | Triggers nightly backup via SSH addon |
 | `git_backup.sh` | Backup script: checkouts ha-backup, merges main, commits, pushes, opens PR |
 | `write_entity_list.sh` | Writes `entity_list.txt` from entities tagged with the `entity_list` HA label |
@@ -85,6 +85,16 @@ Six printers, named after fruits:
 | Dragonfruit | (additional) | Template sensors only so far |
 
 Bambu printers use anchors (`bambu_lab_printers`, `all_printers`) in `automations/printers.yaml` — add new Bambu printers to those anchors.
+
+### Slack cancel button
+
+Print Starting, Print Progress, Print Paused, and Gadget AI notifications include a Slack Block Kit "Cancel Print" button (Bambu printers only). Clicking it triggers a confirmation dialog, then POSTs to an HA webhook that presses `button.{printer}_stop_printing` and responds in Slack.
+
+- The button uses `action_id: cancel_bambu_print` with the printer name as `value`
+- The webhook automation is in `automations/webhooks.yaml` (`Slack – Cancel Bambu Print`)
+- `rest_command.slack_respond` in `configuration.yaml` handles the Slack response via `response_url`
+- Requires Slack app Interactivity enabled with Request URL pointing to the HA webhook
+- Secret: `slack_cancel_print_webhook_id` in `secrets.yaml`
 
 ---
 

--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -58,6 +58,15 @@
         %}{% if e %}{{ e }}{% else %}{% set s = states("sensor."+printer+"_print_time_left")|int(0)
         %}{% if s > 0 %}{{ now() + timedelta(seconds=s) }}{% endif %}{% endif %}'
       thread_ts: '{{ states("input_text."+printer+"_slack_thread_ts") }}'
+  - variables:
+      progress_msg: ":speech_balloon: {{ states('sensor.'+printer+'_print_progress',
+        with_unit=True) }}{% if end_dt %} | {% set secs = (as_timestamp(end_dt) - as_timestamp(now()))
+        | int(0) %}{% set h = secs // 3600 %}{% set m = (secs % 3600) // 60 %}{{ h
+        }}h {{ '%02d' | format(m) }}m (ends {{ as_timestamp(end_dt) | timestamp_custom('%I:%M
+        %p') }}){% endif %} — {% if display_name != object_name %}@{{display_name}},
+        {% endif %}{{object_name}} {% set prog = states('sensor.'+printer+'_print_progress')
+        | int(0) %}{% if prog >= 90 %}almost done!{% elif prog >= 50 %}halfway there!{%
+        else %}printing away!{% endif %} {{states('input_text.'+printer+'_stream')}}"
   - choose:
     - conditions:
       - condition: template
@@ -65,33 +74,73 @@
       sequence:
       - data:
           target: "#3dprint-info"
-          message: ":speech_balloon: {{ states('sensor.'+printer+'_print_progress', with_unit=True)
-            }}{% if end_dt %} | {% set secs = (as_timestamp(end_dt) - as_timestamp(now()))
-            | int(0) %}{% set h = secs // 3600 %}{% set m = (secs % 3600) // 60 %}{{ h
-            }}h {{ '%02d' | format(m) }}m (ends {{ as_timestamp(end_dt) | timestamp_custom('%I:%M
-            %p') }}){% endif %} — {% if display_name != object_name %}@{{display_name}},
-            {% endif %}{{object_name}} {% set prog = states('sensor.'+printer+'_print_progress')
-            | int(0) %}{% if prog >= 90 %}almost done!{% elif prog >= 50 %}halfway there!{%
-            else %}printing away!{% endif %} {{states('input_text.'+printer+'_stream')}}"
+          message: "{{ progress_msg }}"
           data:
             username: '{{ printer | capitalize }}'
             icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
             thread_ts: '{{ thread_ts }}'
+            blocks:
+            - type: section
+              text:
+                type: mrkdwn
+                text: "{{ progress_msg }}"
+            - type: actions
+              elements:
+              - type: button
+                text:
+                  type: plain_text
+                  text: "Cancel Print"
+                style: danger
+                action_id: cancel_bambu_print
+                value: "{{ printer }}"
+                confirm:
+                  title:
+                    type: plain_text
+                    text: "Cancel Print?"
+                  text:
+                    type: mrkdwn
+                    text: "This will stop the current print. Are you sure?"
+                  confirm:
+                    type: plain_text
+                    text: "Yes, cancel it"
+                  deny:
+                    type: plain_text
+                    text: "Never mind"
         action: notify.make_nashville
     default:
     - data:
         target: "#3dprint-info"
-        message: ":speech_balloon: {{ states('sensor.'+printer+'_print_progress', with_unit=True)
-          }}{% if end_dt %} | {% set secs = (as_timestamp(end_dt) - as_timestamp(now()))
-          | int(0) %}{% set h = secs // 3600 %}{% set m = (secs % 3600) // 60 %}{{ h
-          }}h {{ '%02d' | format(m) }}m (ends {{ as_timestamp(end_dt) | timestamp_custom('%I:%M
-          %p') }}){% endif %} — {% if display_name != object_name %}@{{display_name}},
-          {% endif %}{{object_name}} {% set prog = states('sensor.'+printer+'_print_progress')
-          | int(0) %}{% if prog >= 90 %}almost done!{% elif prog >= 50 %}halfway there!{%
-          else %}printing away!{% endif %} {{states('input_text.'+printer+'_stream')}}"
+        message: "{{ progress_msg }}"
         data:
           username: '{{ printer | capitalize }}'
           icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+          blocks:
+          - type: section
+            text:
+              type: mrkdwn
+              text: "{{ progress_msg }}"
+          - type: actions
+            elements:
+            - type: button
+              text:
+                type: plain_text
+                text: "Cancel Print"
+              style: danger
+              action_id: cancel_bambu_print
+              value: "{{ printer }}"
+              confirm:
+                title:
+                  type: plain_text
+                  text: "Cancel Print?"
+                text:
+                  type: mrkdwn
+                  text: "This will stop the current print. Are you sure?"
+                confirm:
+                  type: plain_text
+                  text: "Yes, cancel it"
+                deny:
+                  type: plain_text
+                  text: "Never mind"
       action: notify.make_nashville
   mode: single
 - id: '1722144402850'
@@ -146,12 +195,17 @@
         or end_dt %} — {% endif %}{% if display_name != object_name %}@{{display_name}},
         {% endif %}{{object_name}} is underway!{% if bed_type %} on a {{bed_type}}{%
         endif %}. {{states('input_text.'+printer+'_stream')}}"
+  - variables:
+      is_bambu: "{{ printer in ['kiwi','mango','papaya','strawberry','huckleberry'] }}"
+      blocks: >-
+        {% if is_bambu %}[{"type":"section","text":{"type":"mrkdwn","text":{{ msg | tojson }}}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"Cancel Print"},"style":"danger","action_id":"cancel_bambu_print","value":"{{ printer }}","confirm":{"title":{"type":"plain_text","text":"Cancel Print?"},"text":{"type":"mrkdwn","text":"This will stop the current print. Are you sure?"},"confirm":{"type":"plain_text","text":"Yes, cancel it"},"deny":{"type":"plain_text","text":"Never mind"}}}]}]{% endif %}
   - action: rest_command.slack_post_3dprint
     data:
       channel: "#3dprint-info"
       text: "{{ msg }}"
       username: "{{ printer | capitalize }}"
       icon_emoji: ":{{ 'kiwifruit' if printer == 'kiwi' else printer }}:"
+      blocks: "{{ blocks }}"
     response_variable: slack_response
   - action: input_text.set_value
     target:
@@ -372,6 +426,13 @@
         %}{% if e %}{{ e }}{% else %}{% set s = states("sensor."+printer+"_print_time_left")|int(0)
         %}{% if s > 0 %}{{ now() + timedelta(seconds=s) }}{% endif %}{% endif %}'
       thread_ts: '{{ states("input_text."+printer+"_slack_thread_ts") }}'
+  - variables:
+      paused_msg: ':double_vertical_bar: {{progress}}%{% if end_dt %} | {% set secs =
+        (as_timestamp(end_dt) - as_timestamp(now())) | int(0) %}{% set h = secs //
+        3600 %}{% set m = (secs % 3600) // 60 %}{{ h }}h {{ ''%02d'' | format(m)
+        }}m (ends {{ as_timestamp(end_dt) | timestamp_custom(''%I:%M %p'') }}){% endif
+        %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
+        is on hold. Head over when you get a chance! {{states(''input_text.''+printer+''_stream'')}}'
   - choose:
     - conditions:
       - condition: template
@@ -379,29 +440,73 @@
       sequence:
       - data:
           target: "#3dprint-info"
-          message: ':double_vertical_bar: {{progress}}%{% if end_dt %} | {% set secs =
-            (as_timestamp(end_dt) - as_timestamp(now())) | int(0) %}{% set h = secs //
-            3600 %}{% set m = (secs % 3600) // 60 %}{{ h }}h {{ ''%02d'' | format(m)
-            }}m (ends {{ as_timestamp(end_dt) | timestamp_custom(''%I:%M %p'') }}){% endif
-            %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
-            is on hold. Head over when you get a chance! {{states(''input_text.''+printer+''_stream'')}}'
+          message: "{{ paused_msg }}"
           data:
             username: '{{ printer | capitalize }}'
             icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
             thread_ts: '{{ thread_ts }}'
+            blocks:
+            - type: section
+              text:
+                type: mrkdwn
+                text: "{{ paused_msg }}"
+            - type: actions
+              elements:
+              - type: button
+                text:
+                  type: plain_text
+                  text: "Cancel Print"
+                style: danger
+                action_id: cancel_bambu_print
+                value: "{{ printer }}"
+                confirm:
+                  title:
+                    type: plain_text
+                    text: "Cancel Print?"
+                  text:
+                    type: mrkdwn
+                    text: "This will stop the current print. Are you sure?"
+                  confirm:
+                    type: plain_text
+                    text: "Yes, cancel it"
+                  deny:
+                    type: plain_text
+                    text: "Never mind"
         action: notify.make_nashville
     default:
     - data:
         target: "#3dprint-info"
-        message: ':double_vertical_bar: {{progress}}%{% if end_dt %} | {% set secs =
-          (as_timestamp(end_dt) - as_timestamp(now())) | int(0) %}{% set h = secs //
-          3600 %}{% set m = (secs % 3600) // 60 %}{{ h }}h {{ ''%02d'' | format(m)
-          }}m (ends {{ as_timestamp(end_dt) | timestamp_custom(''%I:%M %p'') }}){% endif
-          %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
-          is on hold. Head over when you get a chance! {{states(''input_text.''+printer+''_stream'')}}'
+        message: "{{ paused_msg }}"
         data:
           username: '{{ printer | capitalize }}'
           icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+          blocks:
+          - type: section
+            text:
+              type: mrkdwn
+              text: "{{ paused_msg }}"
+          - type: actions
+            elements:
+            - type: button
+              text:
+                type: plain_text
+                text: "Cancel Print"
+              style: danger
+              action_id: cancel_bambu_print
+              value: "{{ printer }}"
+              confirm:
+                title:
+                  type: plain_text
+                  text: "Cancel Print?"
+                text:
+                  type: mrkdwn
+                  text: "This will stop the current print. Are you sure?"
+                confirm:
+                  type: plain_text
+                  text: "Yes, cancel it"
+                deny:
+                  type: plain_text
+                  text: "Never mind"
       action: notify.make_nashville
   mode: parallel
   max: 4

--- a/automations/webhooks.yaml
+++ b/automations/webhooks.yaml
@@ -61,6 +61,11 @@
       progress: '{{ trigger.json.Progress | default(0) }}'
       stream_url: '{{ states("input_text." + printer_id + "_stream") }}'
       thread_ts: '{{ states("input_text." + printer_id + "_slack_thread_ts") }}'
+  - variables:
+      gadget_msg: '{{ progress }}% — {% if event_type == 8 %}:rotating_light: Gadget paused
+        {{ printer_name }} after detecting a failure{% else %}:warning: Gadget detected
+        a possible failure on {{ printer_name }}{% endif %}{% if file_name %} printing
+        {{ file_name }}{% endif %}. {{ stream_url }}'
   - choose:
     - conditions:
       - condition: template
@@ -69,24 +74,103 @@
       - action: notify.make_nashville
         data:
           target: "#3dprint-info"
-          message: '{{ progress }}% — {% if event_type == 8 %}:rotating_light: Gadget paused
-            {{ printer_name }} after detecting a failure{% else %}:warning: Gadget detected
-            a possible failure on {{ printer_name }}{% endif %}{% if file_name %} printing
-            {{ file_name }}{% endif %}. {{ stream_url }}'
+          message: "{{ gadget_msg }}"
           data:
             username: Gadget
             icon: robot_face
             thread_ts: '{{ thread_ts }}'
+            blocks:
+            - type: section
+              text:
+                type: mrkdwn
+                text: "{{ gadget_msg }}"
+            - type: actions
+              elements:
+              - type: button
+                text:
+                  type: plain_text
+                  text: "Cancel Print"
+                style: danger
+                action_id: cancel_bambu_print
+                value: "{{ printer_id }}"
+                confirm:
+                  title:
+                    type: plain_text
+                    text: "Cancel Print?"
+                  text:
+                    type: mrkdwn
+                    text: "This will stop the current print. Are you sure?"
+                  confirm:
+                    type: plain_text
+                    text: "Yes, cancel it"
+                  deny:
+                    type: plain_text
+                    text: "Never mind"
     default:
     - action: notify.make_nashville
       data:
         target: "#3dprint-info"
-        message: '{{ progress }}% — {% if event_type == 8 %}:rotating_light: Gadget paused
-          {{ printer_name }} after detecting a failure{% else %}:warning: Gadget detected
-          a possible failure on {{ printer_name }}{% endif %}{% if file_name %} printing
-          {{ file_name }}{% endif %}. {{ stream_url }}'
+        message: "{{ gadget_msg }}"
         data:
           username: Gadget
           icon: robot_face
+          blocks:
+          - type: section
+            text:
+              type: mrkdwn
+              text: "{{ gadget_msg }}"
+          - type: actions
+            elements:
+            - type: button
+              text:
+                type: plain_text
+                text: "Cancel Print"
+              style: danger
+              action_id: cancel_bambu_print
+              value: "{{ printer_id }}"
+              confirm:
+                title:
+                  type: plain_text
+                  text: "Cancel Print?"
+                text:
+                  type: mrkdwn
+                  text: "This will stop the current print. Are you sure?"
+                confirm:
+                  type: plain_text
+                  text: "Yes, cancel it"
+                deny:
+                  type: plain_text
+                  text: "Never mind"
   mode: parallel
   max: 5
+- id: slack_cancel_bambu_print
+  alias: Slack – Cancel Bambu Print
+  description: Handles Slack interactive button clicks to cancel a Bambu Lab print
+  triggers:
+  - trigger: webhook
+    webhook_id: !secret slack_cancel_print_webhook_id
+    allowed_methods:
+    - POST
+    local_only: false
+  conditions:
+  - condition: template
+    value_template: >
+      {% set payload = trigger.data.get('payload', '{}') | from_json %}
+      {% set action = (payload.get('actions', [{}])[0]) %}
+      {{ action.get('action_id', '') == 'cancel_bambu_print'
+         and action.get('value', '') in ['kiwi','mango','papaya','strawberry','huckleberry'] }}
+  actions:
+  - variables:
+      payload: "{{ trigger.data.get('payload', '{}') | from_json }}"
+      printer: "{{ payload.actions[0].value }}"
+      response_url: "{{ payload.response_url }}"
+      slack_user: "{{ payload.user.name | default('Someone') }}"
+  - action: button.press
+    target:
+      entity_id: "button.{{ printer }}_stop_printing"
+  - action: rest_command.slack_respond
+    data:
+      response_url: "{{ response_url }}"
+      text: ":octagonal_sign: {{ slack_user }} cancelled the print on {{ printer | capitalize }}."
+  mode: parallel
+  max: 6

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -43,7 +43,16 @@ rest_command:
       Content-Type: "application/json; charset=utf-8"
     payload: >-
       {"channel": {{ channel | tojson }}, "text": {{ text | tojson }},
-       "username": {{ username | tojson }}, "icon_emoji": {{ icon_emoji | tojson }}}
+       "username": {{ username | tojson }}, "icon_emoji": {{ icon_emoji | tojson }}
+       {% if blocks is defined and blocks %}, "blocks": {{ blocks }}{% endif %}}
+  slack_respond:
+    url: "{{ response_url }}"
+    method: POST
+    headers:
+      Content-Type: "application/json; charset=utf-8"
+    payload: >-
+      {"replace_original": false, "response_type": "in_channel",
+       "text": {{ text | tojson }}}
   eventbrite_get_event:
     url: "{{ url }}"
     method: GET


### PR DESCRIPTION
## Summary
- Printer notifications (Starting, Progress, Paused, Gadget AI) now include a Block Kit "Cancel Print" button for Bambu Lab printers
- Clicking the button shows a confirmation dialog ("Are you sure?"), then triggers a webhook automation that presses `button.{printer}_stop_printing` and posts an acknowledgment in Slack
- Adds `rest_command.slack_respond` for responding to Slack interaction callbacks and updates `rest_command.slack_post_3dprint` to support optional blocks

## Setup required
1. Add `slack_cancel_print_webhook_id` to `secrets.yaml` on the HA host
2. Enable **Interactivity** in the Slack app settings and set the **Request URL** to `https://<ha-url>/api/webhook/<webhook-id>`

## Test plan
- [ ] Verify YAML validation passes in CI
- [ ] Add secret to HA host and configure Slack app interactivity
- [ ] Trigger a Bambu print and confirm the "Cancel Print" button appears on Starting, Progress, and Paused notifications
- [ ] Click "Cancel Print" and verify the confirmation dialog appears
- [ ] Confirm the dialog and verify the print stops and Slack posts an acknowledgment
- [ ] Verify Gadget AI notifications also show the cancel button
- [ ] Verify Pineapple notifications still work without blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)