### PR TITLE
Change Slack button from cancel to pause

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,12 +86,12 @@ Six printers, named after fruits:
 
 Bambu printers use anchors (`bambu_lab_printers`, `all_printers`) in `automations/printers.yaml` — add new Bambu printers to those anchors.
 
-### Slack cancel button
+### Slack pause button
 
-Print Starting, Print Progress, Print Paused, and Gadget AI notifications include a Slack Block Kit "Cancel Print" button (Bambu printers only). Clicking it triggers a confirmation dialog, then POSTs to an HA webhook that presses `button.{printer}_stop_printing` and responds in Slack.
+Print Starting, Print Progress, Print Paused, and Gadget AI notifications include a Slack Block Kit "Pause Print" button (Bambu printers only). Clicking it triggers a confirmation dialog, then POSTs to an HA webhook that presses `button.{printer}_pause_printing` and responds in Slack.
 
-- The button uses `action_id: cancel_bambu_print` with the printer name as `value`
-- The webhook automation is in `automations/webhooks.yaml` (`Slack – Cancel Bambu Print`)
+- The button uses `action_id: pause_bambu_print` with the printer name as `value`
+- The webhook automation is in `automations/webhooks.yaml` (`Slack – Pause Bambu Print`)
 - `rest_command.slack_respond` in `configuration.yaml` handles the Slack response via `response_url`
 - Requires Slack app Interactivity enabled with Request URL pointing to the HA webhook
 - Secret: `slack_cancel_print_webhook_id` in `secrets.yaml`

--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -89,20 +89,19 @@
               - type: button
                 text:
                   type: plain_text
-                  text: "Cancel Print"
-                style: danger
-                action_id: cancel_bambu_print
+                  text: "Pause Print"
+                action_id: pause_bambu_print
                 value: "{{ printer }}"
                 confirm:
                   title:
                     type: plain_text
-                    text: "Cancel Print?"
+                    text: "Pause Print?"
                   text:
                     type: mrkdwn
-                    text: "This will stop the current print. Are you sure?"
+                    text: "This will pause the current print. Are you sure?"
                   confirm:
                     type: plain_text
-                    text: "Yes, cancel it"
+                    text: "Yes, pause it"
                   deny:
                     type: plain_text
                     text: "Never mind"
@@ -124,20 +123,19 @@
             - type: button
               text:
                 type: plain_text
-                text: "Cancel Print"
-              style: danger
-              action_id: cancel_bambu_print
+                text: "Pause Print"
+              action_id: pause_bambu_print
               value: "{{ printer }}"
               confirm:
                 title:
                   type: plain_text
-                  text: "Cancel Print?"
+                  text: "Pause Print?"
                 text:
                   type: mrkdwn
-                  text: "This will stop the current print. Are you sure?"
+                  text: "This will pause the current print. Are you sure?"
                 confirm:
                   type: plain_text
-                  text: "Yes, cancel it"
+                  text: "Yes, pause it"
                 deny:
                   type: plain_text
                   text: "Never mind"
@@ -198,7 +196,7 @@
   - variables:
       is_bambu: "{{ printer in ['kiwi','mango','papaya','strawberry','huckleberry'] }}"
       blocks: >-
-        {% if is_bambu %}[{"type":"section","text":{"type":"mrkdwn","text":{{ msg | tojson }}}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"Cancel Print"},"style":"danger","action_id":"cancel_bambu_print","value":"{{ printer }}","confirm":{"title":{"type":"plain_text","text":"Cancel Print?"},"text":{"type":"mrkdwn","text":"This will stop the current print. Are you sure?"},"confirm":{"type":"plain_text","text":"Yes, cancel it"},"deny":{"type":"plain_text","text":"Never mind"}}}]}]{% endif %}
+        {% if is_bambu %}[{"type":"section","text":{"type":"mrkdwn","text":{{ msg | tojson }}}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"Pause Print"},"action_id":"pause_bambu_print","value":"{{ printer }}","confirm":{"title":{"type":"plain_text","text":"Pause Print?"},"text":{"type":"mrkdwn","text":"This will pause the current print. Are you sure?"},"confirm":{"type":"plain_text","text":"Yes, pause it"},"deny":{"type":"plain_text","text":"Never mind"}}}]}]{% endif %}
   - action: rest_command.slack_post_3dprint
     data:
       channel: "#3dprint-info"
@@ -455,20 +453,19 @@
               - type: button
                 text:
                   type: plain_text
-                  text: "Cancel Print"
-                style: danger
-                action_id: cancel_bambu_print
+                  text: "Pause Print"
+                action_id: pause_bambu_print
                 value: "{{ printer }}"
                 confirm:
                   title:
                     type: plain_text
-                    text: "Cancel Print?"
+                    text: "Pause Print?"
                   text:
                     type: mrkdwn
-                    text: "This will stop the current print. Are you sure?"
+                    text: "This will pause the current print. Are you sure?"
                   confirm:
                     type: plain_text
-                    text: "Yes, cancel it"
+                    text: "Yes, pause it"
                   deny:
                     type: plain_text
                     text: "Never mind"
@@ -490,20 +487,19 @@
             - type: button
               text:
                 type: plain_text
-                text: "Cancel Print"
-              style: danger
-              action_id: cancel_bambu_print
+                text: "Pause Print"
+              action_id: pause_bambu_print
               value: "{{ printer }}"
               confirm:
                 title:
                   type: plain_text
-                  text: "Cancel Print?"
+                  text: "Pause Print?"
                 text:
                   type: mrkdwn
-                  text: "This will stop the current print. Are you sure?"
+                  text: "This will pause the current print. Are you sure?"
                 confirm:
                   type: plain_text
-                  text: "Yes, cancel it"
+                  text: "Yes, pause it"
                 deny:
                   type: plain_text
                   text: "Never mind"

--- a/automations/webhooks.yaml
+++ b/automations/webhooks.yaml
@@ -89,20 +89,19 @@
               - type: button
                 text:
                   type: plain_text
-                  text: "Cancel Print"
-                style: danger
-                action_id: cancel_bambu_print
+                  text: "Pause Print"
+                action_id: pause_bambu_print
                 value: "{{ printer_id }}"
                 confirm:
                   title:
                     type: plain_text
-                    text: "Cancel Print?"
+                    text: "Pause Print?"
                   text:
                     type: mrkdwn
-                    text: "This will stop the current print. Are you sure?"
+                    text: "This will pause the current print. Are you sure?"
                   confirm:
                     type: plain_text
-                    text: "Yes, cancel it"
+                    text: "Yes, pause it"
                   deny:
                     type: plain_text
                     text: "Never mind"
@@ -124,28 +123,27 @@
             - type: button
               text:
                 type: plain_text
-                text: "Cancel Print"
-              style: danger
-              action_id: cancel_bambu_print
+                text: "Pause Print"
+              action_id: pause_bambu_print
               value: "{{ printer_id }}"
               confirm:
                 title:
                   type: plain_text
-                  text: "Cancel Print?"
+                  text: "Pause Print?"
                 text:
                   type: mrkdwn
-                  text: "This will stop the current print. Are you sure?"
+                  text: "This will pause the current print. Are you sure?"
                 confirm:
                   type: plain_text
-                  text: "Yes, cancel it"
+                  text: "Yes, pause it"
                 deny:
                   type: plain_text
                   text: "Never mind"
   mode: parallel
   max: 5
-- id: slack_cancel_bambu_print
-  alias: Slack – Cancel Bambu Print
-  description: Handles Slack interactive button clicks to cancel a Bambu Lab print
+- id: slack_pause_bambu_print
+  alias: Slack – Pause Bambu Print
+  description: Handles Slack interactive button clicks to pause a Bambu Lab print
   triggers:
   - trigger: webhook
     webhook_id: !secret slack_cancel_print_webhook_id
@@ -157,7 +155,7 @@
     value_template: >
       {% set payload = trigger.data.get('payload', '{}') | from_json %}
       {% set action = (payload.get('actions', [{}])[0]) %}
-      {{ action.get('action_id', '') == 'cancel_bambu_print'
+      {{ action.get('action_id', '') == 'pause_bambu_print'
          and action.get('value', '') in ['kiwi','mango','papaya','strawberry','huckleberry'] }}
   actions:
   - variables:
@@ -167,10 +165,10 @@
       slack_user: "{{ payload.user.name | default('Someone') }}"
   - action: button.press
     target:
-      entity_id: "button.{{ printer }}_stop_printing"
+      entity_id: "button.{{ printer }}_pause_printing"
   - action: rest_command.slack_respond
     data:
       response_url: "{{ response_url }}"
-      text: ":octagonal_sign: {{ slack_user }} cancelled the print on {{ printer | capitalize }}."
+      text: ":double_vertical_bar: {{ slack_user }} paused the print on {{ printer | capitalize }}."
   mode: parallel
   max: 6


### PR DESCRIPTION
## Summary
- Swaps the "Cancel Print" button to "Pause Print" across all four notification types (Starting, Progress, Paused, Gadget AI)
- Webhook automation now presses `button.{printer}_pause_printing` instead of `stop_printing`
- Removes `danger` style from button since pausing is non-destructive
- Updates confirmation dialog and Slack response message to reflect pause action
- Updates CLAUDE.md documentation

**Builds on** #65

## Test plan
- [ ] Verify YAML validation passes in CI
- [ ] Trigger a Bambu print and confirm the "Pause Print" button appears on notifications
- [ ] Click "Pause Print" and verify the confirmation dialog says "This will pause the current print"
- [ ] Confirm and verify the print pauses and Slack posts ":double_vertical_bar: {user} paused the print on {Printer}."

🤖 Generated with [Claude Code](https://claude.com/claude-code)