### PR TITLE
Improve deploy workflow step names for clarity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Home Assistant
+name: Deploy Config to Home Assistant
 
 on:
   push:
@@ -17,13 +17,14 @@ on:
 
 jobs:
   deploy:
+    name: Pull, validate, and apply config
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - name: Detect if full restart required
+      - name: Check if configuration.yaml changed (requires full restart)
         id: restart_check
         run: |
           if git diff --name-only HEAD~1 HEAD | grep -qE '^(configuration\.yaml)'; then
@@ -32,18 +33,17 @@ jobs:
             echo "required=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Pull latest config on HA
+      - name: Git pull config on HA host
         run: |
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/shell_command/git_pull"
 
-      # Give git pull a moment to finish before validating
-      - name: Wait for pull
+      - name: Wait 5s for git pull to finish
         run: sleep 5
 
-      - name: Validate config
+      - name: Validate HA config via check_config API
         run: |
           result=$(curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
@@ -54,7 +54,7 @@ jobs:
 
       # --- Restart path ---
 
-      - name: Notify restart
+      - name: Slack — Notify restart beginning
         if: steps.restart_check.outputs.required == 'true'
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"
@@ -69,7 +69,7 @@ jobs:
             -d "$body" \
             "${{ secrets.HA_URL }}/api/services/notify/make_nashville"
 
-      - name: Restart HA
+      - name: Trigger HA full restart
         if: steps.restart_check.outputs.required == 'true'
         run: |
           # HA shuts down before it can respond, so curl will always
@@ -81,7 +81,7 @@ jobs:
             "${{ secrets.HA_URL }}/api/services/homeassistant/restart" \
             || true
 
-      - name: Wait for HA to restart
+      - name: Poll /api/ until HA is back online (up to 5 min)
         if: steps.restart_check.outputs.required == 'true'
         run: |
           echo "Waiting for HA to come back online..."
@@ -99,7 +99,7 @@ jobs:
           echo "HA did not come back within 5 minutes"
           exit 1
 
-      - name: Notify restart complete
+      - name: Slack — Restart complete
         if: steps.restart_check.outputs.required == 'true'
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"
@@ -116,7 +116,7 @@ jobs:
 
       # --- Reload path ---
 
-      - name: Reload automations
+      - name: Hot-reload automations
         if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
@@ -124,7 +124,7 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/automation/reload"
 
-      - name: Reload scripts
+      - name: Hot-reload scripts
         if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
@@ -132,7 +132,7 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/script/reload"
 
-      - name: Reload scenes
+      - name: Hot-reload scenes
         if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
@@ -140,7 +140,7 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/scene/reload"
 
-      - name: Reload themes
+      - name: Hot-reload themes
         if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
@@ -148,7 +148,7 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/frontend/reload_themes"
 
-      - name: Reload core config (templates)
+      - name: Hot-reload core config and templates
         if: steps.restart_check.outputs.required == 'false'
         run: |
           curl -f -s -X POST \
@@ -156,7 +156,7 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ secrets.HA_URL }}/api/services/homeassistant/reload_core_config"
 
-      - name: Notify reload
+      - name: Slack — Hot-reload complete
         if: steps.restart_check.outputs.required == 'false'
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"
@@ -173,7 +173,7 @@ jobs:
 
       # --- Post-deploy backup ---
 
-      - name: Trigger config backup
+      - name: Trigger nightly backup via SSH addon
         if: success()
         run: |
           curl -s -X POST \
@@ -184,7 +184,7 @@ jobs:
 
       # --- Failure notification ---
 
-      - name: Notify failure
+      - name: Slack — Deploy failed
         if: failure()
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"


### PR DESCRIPTION
## Summary
- Rename workflow from "Deploy to Home Assistant" to "Deploy Config to Home Assistant"
- Add descriptive job name: "Pull, validate, and apply config"
- Rename all steps to be self-descriptive at a glance in the Actions UI
- Prefix Slack notification steps with "Slack —"
- Label reload steps as "Hot-reload" to distinguish from full restart
- Add inline context like "(requires full restart)" and "(up to 5 min)"

No functional changes — names only.

## Test plan
- [ ] Verify YAML validation passes
- [ ] Confirm step names render correctly in GitHub Actions UI on next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)