### PR TITLE
Add morning-of event alert and update signup digest wording

### DIFF
--- a/automations/eventbrite.yaml
+++ b/automations/eventbrite.yaml
@@ -78,7 +78,40 @@
       data:
         target: "#integrations_sandbox"
         message: |-
-          :wave: *Eventbrite Signups Yesterday* ({{ count }} new)
+          :wave: *Eventbrite Signups — Last 24 Hours* ({{ count }} new)
+          {{ event_lines }}
+        data:
+          username: Eventbrite
+          icon: calendar
+  mode: single
+
+- id: 'eventbrite_event_day_alert'
+  alias: Eventbrite Event Day Alert
+  triggers:
+    - trigger: time
+      at: '08:00:00'
+  conditions:
+    - condition: template
+      value_template: >
+        {{ states('sensor.eventbrite_today_events') | int(0) > 0
+           and state_attr('sensor.eventbrite_today_events', 'events') is not none }}
+  actions:
+    - variables:
+        events: "{{ state_attr('sensor.eventbrite_today_events', 'events') }}"
+    - variables:
+        event_lines: |-
+          {% for event in events %}
+          {% set signups = event.ticket_classes | default([]) | map(attribute='quantity_sold') | map('int', default=0) | sum %}
+          *{{ event.name.text }}*
+          :clock1: {{ event.start.local | as_datetime | timestamp_custom('%-I:%M %p') }}
+          :busts_in_silhouette: {{ signups }} signup{{ 's' if signups != 1 }}
+          :link: {{ event.url }}
+          {% endfor %}
+    - action: notify.make_nashville
+      data:
+        target: "#integrations_sandbox"
+        message: |-
+          :mega: *Events Today*
           {{ event_lines }}
         data:
           username: Eventbrite

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -105,6 +105,7 @@ recorder:
       - sensor.filament_store_light_illuminance
       - input_boolean.facilities_pulse_verbose
       - sensor.eventbrite_daily_signups
+      - sensor.eventbrite_today_events
     entity_globs:
       # Fan speeds / signals (already present)
       - sensor.*_wi_fi_signal
@@ -140,6 +141,16 @@ rest:
         value_template: "{{ (value_json.pagination | default({})).object_count | default(0) }}"
         json_attributes:
           - attendees
+  - resource_template: >-
+      https://www.eventbriteapi.com/v3/organizations/{{ states('input_text.eventbrite_org_id') }}/events/?start_date.range_start={{ now().strftime('%Y-%m-%dT00:00:00') }}&start_date.range_end={{ now().strftime('%Y-%m-%dT23:59:59') }}&expand=ticket_classes&status=live
+    headers:
+      Authorization: !secret eventbrite_token_header
+    scan_interval: 3600
+    sensor:
+      - name: Eventbrite Today Events
+        value_template: "{{ (value_json.events | default([])) | length }}"
+        json_attributes:
+          - events
 
 template:
   - sensor:


### PR DESCRIPTION
## Summary
- Changed daily signup digest message from "Yesterday" to "Last 24 Hours" to better reflect the actual query window
- Added new `Eventbrite Event Day Alert` automation that fires at 8:00 AM on days with events, posting event name, start time, signup count, and link to `#integrations_sandbox`
- Added `Eventbrite Today Events` REST sensor polling the Eventbrite events API hourly for today's live events with ticket class data
- Excluded new sensor from recorder to avoid database bloat

## Test plan
- [ ] Verify YAML validation passes in CI
- [ ] Confirm `sensor.eventbrite_today_events` populates correctly on a day with events
- [ ] Confirm the 8 AM automation fires and posts to `#integrations_sandbox` with correct event details and signup counts
- [ ] Confirm the daily signup digest now says "Last 24 Hours"
- [ ] Verify no alerts fire on days without events

🤖 Generated with [Claude Code](https://claude.com/claude-code)