### PR TITLE
Fix Slack thread_ts never being captured

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -209,7 +209,7 @@
     target:
       entity_id: "input_text.{{ printer }}_slack_thread_ts"
     data:
-      value: "{% set ts = (slack_response.content | from_json).ts | default('') | string %}{{ ts if '.' in ts else '' }}"
+      value: "{% set ts = slack_response['content']['ts'] | default('') | string %}{{ ts if '.' in ts else '' }}"
   - if:
     - condition: template
       value_template: "{{ printer == 'pineapple' }}"


### PR DESCRIPTION
## Summary
- `rest_command` response `content` is already parsed JSON — applying `| from_json` to a dict silently failed
- This caused `thread_ts` to always be empty, so all printer notifications posted as top-level messages instead of threaded replies
- Removed `| from_json` and switched to direct dict access matching the [HA docs pattern](https://www.home-assistant.io/integrations/rest_command/)

## Test plan
- [ ] YAML validation CI passes
- [ ] Start a print → confirm thread_ts is stored in `input_text.{printer}_slack_thread_ts`
- [ ] Confirm subsequent lifecycle messages (progress, pause, finish, error) appear as threaded replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)