### PR TITLE
Add runtime health monitoring automations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,15 @@ jobs:
             -d "$body" \
             "${{ secrets.HA_URL }}/api/services/notify/make_nashville"
 
+      - name: Flag deploy restart in progress
+        if: steps.restart_check.outputs.required == 'true'
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"entity_id": "input_boolean.deploy_restart_in_progress"}' \
+            "${{ secrets.HA_URL }}/api/services/input_boolean/turn_on"
+
       - name: Trigger HA full restart
         if: steps.restart_check.outputs.required == 'true'
         run: |

--- a/automations/health.yaml
+++ b/automations/health.yaml
@@ -1,0 +1,100 @@
+- id: ha_startup_notification
+  alias: HA Startup Notification
+  triggers:
+  - trigger: homeassistant
+    event: start
+  actions:
+  - delay:
+      seconds: 60
+  - if:
+    - condition: state
+      entity_id: input_boolean.deploy_restart_in_progress
+      state: 'on'
+    then:
+    - action: input_boolean.turn_off
+      target:
+        entity_id: input_boolean.deploy_restart_in_progress
+    else:
+    - action: notify.make_nashville
+      data:
+        target: "#integrations_sandbox"
+        message: ':white_check_mark: Home Assistant is online.'
+        data:
+          username: Home Assistant
+          icon: house
+  mode: single
+- id: slack_bot_health_check
+  alias: Slack Bot Health Check
+  triggers:
+  - trigger: time_pattern
+    hours: "/6"
+  - trigger: homeassistant
+    event: start
+  actions:
+  - delay:
+      seconds: 90
+  - action: rest_command.slack_auth_test
+    response_variable: slack_health
+  - if:
+    - condition: template
+      value_template: "{{ slack_health['content']['ok'] == true }}"
+    then:
+    - action: persistent_notification.dismiss
+      data:
+        notification_id: slack_bot_unhealthy
+    else:
+    - action: persistent_notification.create
+      data:
+        notification_id: slack_bot_unhealthy
+        title: Slack Bot Unhealthy
+        message: >-
+          Slack auth.test failed. The bot token may be expired or invalid.
+          Response: {{ slack_health['content'] }}
+  mode: single
+- id: eventbrite_sensor_stale
+  alias: Eventbrite Sensor Stale
+  triggers:
+  - entity_id:
+    - sensor.eventbrite_daily_signups
+    - sensor.eventbrite_today_events
+    to:
+    - unavailable
+    - unknown
+    for:
+      hours: 2
+    trigger: state
+  actions:
+  - action: notify.make_nashville
+    data:
+      target: "#integrations_sandbox"
+      message: ':warning: Eventbrite integration may be down — sensor has been unavailable
+        for 2+ hours. Check the API token.'
+      data:
+        username: Home Assistant
+        icon: warning
+  - action: persistent_notification.create
+    data:
+      notification_id: eventbrite_stale
+      title: Eventbrite Sensor Stale
+      message: >-
+        {{ trigger.entity_id }} has been {{ trigger.to_state.state }} for 2+ hours.
+        Check the Eventbrite API token.
+  mode: single
+- id: eventbrite_sensor_recovery
+  alias: Eventbrite Sensor Recovery
+  triggers:
+  - entity_id:
+    - sensor.eventbrite_daily_signups
+    - sensor.eventbrite_today_events
+    from:
+    - unavailable
+    - unknown
+    trigger: state
+  conditions:
+  - condition: template
+    value_template: "{{ trigger.to_state.state not in ['unavailable', 'unknown'] }}"
+  actions:
+  - action: persistent_notification.dismiss
+    data:
+      notification_id: eventbrite_stale
+  mode: single

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -53,6 +53,12 @@ rest_command:
     payload: >-
       {"replace_original": false, "response_type": "in_channel",
        "text": {{ text | tojson }}}
+  slack_auth_test:
+    url: https://slack.com/api/auth.test
+    method: POST
+    headers:
+      Authorization: !secret slack_bot_token_header
+      Content-Type: "application/json; charset=utf-8"
   eventbrite_get_event:
     url: "{{ url }}"
     method: GET
@@ -89,6 +95,9 @@ input_boolean:
   facilities_pulse_verbose:
     name: Facilities Pulse Verbose Mode
     icon: mdi:bell-outline
+  deploy_restart_in_progress:
+    name: Deploy Restart In Progress
+    icon: mdi:restart
 
 recorder:
   purge_keep_days: 14


### PR DESCRIPTION
## Summary
- **HA Startup Notification** — posts to Slack when HA comes online after a crash or power outage. 60s delay prevents flooding during crash loops. Suppresses itself during deploy-triggered restarts via `input_boolean.deploy_restart_in_progress` flag.
- **Slack Bot Health Check** — calls `auth.test` every 6 hours + on startup. Creates a persistent HA notification if the bot token is broken (can't alert via Slack when Slack is down).
- **Eventbrite Sensor Staleness** — alerts when REST sensors are unavailable for 2+ hours, with auto-recovery dismissal.
- All notifications go to `#integrations_sandbox` for testing before moving to `#deployment-feed`.

## Test plan
- [ ] YAML validation CI passes
- [ ] HA config check passes
- [ ] Restart HA manually → startup notification appears in `#integrations_sandbox` after ~60s
- [ ] Deploy via workflow → no duplicate startup notification (flag suppresses it)
- [ ] Verify Slack health check runs on startup (persistent notification dismissed if healthy)
- [ ] Simulate Eventbrite sensor going unavailable → alert after 2h threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)