### PR TITLE
Add Lifecycle Print Resumed notification

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -557,6 +557,120 @@
       action: notify.make_nashville
   mode: parallel
   max: 4
+- id: '1740400002000'
+  alias: Lifecycle Print Resumed
+  triggers:
+  - entity_id: *bambu_lab_printers
+    to:
+    - running
+    for:
+      seconds: 10
+    trigger: state
+    from:
+    - pause
+  - entity_id:
+    - sensor.pineapple_print_status
+    to:
+    - printing
+    for:
+      seconds: 10
+    trigger: state
+    from:
+    - paused
+  actions:
+  - variables:
+      printer: '{{trigger.entity_id.split(''_'')[0].split(''.'')[1]}}'
+      display_name: '{{states("sensor."+printer+"_display_name") }}'
+      object_name: '{{states("sensor."+printer+"_object") }}'
+      progress: '{{states("sensor."+printer+"_print_progress") | int(0)}}'
+      end_dt: '{% set e = as_datetime(states("sensor."+printer+"_end_time"), none)
+        %}{% if e %}{{ e }}{% else %}{% set s = states("sensor."+printer+"_print_time_left")|int(0)
+        %}{% if s > 0 %}{{ now() + timedelta(seconds=s) }}{% endif %}{% endif %}'
+      thread_ts: '{{ states("input_text."+printer+"_slack_thread_ts") }}'
+  - variables:
+      resumed_msg: ':arrow_forward: {{progress}}%{% if end_dt %} | {% set secs =
+        (as_timestamp(end_dt) - as_timestamp(now())) | int(0) %}{% set h = secs //
+        3600 %}{% set m = (secs % 3600) // 60 %}{{ h }}h {{ ''%02d'' | format(m)
+        }}m (ends {{ as_timestamp(end_dt) | timestamp_custom(''%I:%M %p'') }}){% endif
+        %} — {% if display_name != object_name %}@{{display_name}}, {% endif %}{{object_name}}
+        is back at it! {{states(''input_text.''+printer+''_stream'')}}'
+  - variables:
+      is_bambu: "{{ printer in ['kiwi','mango','papaya','strawberry','huckleberry'] }}"
+  - choose:
+    - conditions:
+      - condition: template
+        value_template: "{{ '.' in thread_ts }}"
+      sequence:
+      - data:
+          target: "#3dprint-info"
+          message: "{{ resumed_msg }}"
+          data:
+            username: '{{ printer | capitalize }}'
+            icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+            thread_ts: '{{ thread_ts }}'
+            blocks:
+            - type: section
+              text:
+                type: mrkdwn
+                text: "{{ resumed_msg }}"
+            - type: actions
+              elements:
+              - type: button
+                text:
+                  type: plain_text
+                  text: "Pause Print"
+                action_id: pause_bambu_print
+                value: "{{ printer }}"
+                confirm:
+                  title:
+                    type: plain_text
+                    text: "Pause Print?"
+                  text:
+                    type: mrkdwn
+                    text: "This will pause the current print. Are you sure?"
+                  confirm:
+                    type: plain_text
+                    text: "Yes, pause it"
+                  deny:
+                    type: plain_text
+                    text: "Never mind"
+        action: notify.make_nashville
+    default:
+    - data:
+        target: "#3dprint-info"
+        message: "{{ resumed_msg }}"
+        data:
+          username: '{{ printer | capitalize }}'
+          icon: '{{ ''kiwifruit'' if printer == ''kiwi'' else printer }}'
+          blocks:
+          - type: section
+            text:
+              type: mrkdwn
+              text: "{{ resumed_msg }}"
+          - type: actions
+            elements:
+            - type: button
+              text:
+                type: plain_text
+                text: "Pause Print"
+              action_id: pause_bambu_print
+              value: "{{ printer }}"
+              confirm:
+                title:
+                  type: plain_text
+                  text: "Pause Print?"
+                text:
+                  type: mrkdwn
+                  text: "This will pause the current print. Are you sure?"
+                confirm:
+                  type: plain_text
+                  text: "Yes, pause it"
+                deny:
+                  type: plain_text
+                  text: "Never mind"
+      action: notify.make_nashville
+  mode: parallel
+  max: 4
 - id: '1722445886802'
   alias: Roundup
   triggers:


### PR DESCRIPTION
## Summary
- Adds a new **Lifecycle Print Resumed** automation that fires when a paused print transitions back to running
- Posts to `#3dprint-info` with progress, time remaining, and a "Pause Print" button
- Supports both Bambu (`pause` → `running`) and Pineapple/Prusa (`paused` → `printing`)
- Posts in-thread when a `thread_ts` exists, matching the pattern of all other lifecycle automations

## Test plan
- [ ] Pause a Bambu printer mid-print, then resume — verify Slack notification appears in `#3dprint-info`
- [ ] Confirm the message shows correct progress %, time remaining, and object name
- [ ] Confirm the "Pause Print" button appears and works
- [ ] If a thread exists, confirm the resumed message posts in-thread
- [ ] Pause and resume Pineapple to verify Prusa path triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)