### PR TITLE
Deduplicate repeated names in Eventbrite signup digest

### DIFF
--- a/automations/eventbrite.yaml
+++ b/automations/eventbrite.yaml
@@ -72,7 +72,19 @@
             {% set ns.events = dict(ns.events, **{ename: names}) %}
           {% endfor %}
           {% for event, names in ns.events.items() %}
-          *{{ event }}* — {{ names | join(', ') }}
+            {%- set ns2 = namespace(counts={}) -%}
+            {%- for n in names -%}
+              {%- set ns2.counts = dict(ns2.counts, **{n: ns2.counts.get(n, 0) + 1}) -%}
+            {%- endfor -%}
+            {%- set display = [] -%}
+            {%- for name, c in ns2.counts.items() -%}
+              {%- if c > 1 -%}
+                {%- set display = display + [name ~ ' (' ~ c ~ ')'] -%}
+              {%- else -%}
+                {%- set display = display + [name] -%}
+              {%- endif -%}
+            {%- endfor %}
+          *{{ event }}* — {{ display | join(', ') }}
           {% endfor %}
     - action: notify.make_nashville
       data:


### PR DESCRIPTION
## Summary
- Deduplicates repeated attendee names in the daily Eventbrite signup digest
- Names appearing multiple times for the same event now show once with a count, e.g. `Alice (2), Bob` instead of `Alice, Alice, Bob`

## Test plan
- [ ] Verify digest renders correctly when all names are unique (no counts shown)
- [ ] Verify digest renders correctly when a name repeats (count shown in parentheses)
- [ ] Verify multiple events still display correctly with their own name lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)