### PR TITLE
Add one-week-out alert and low-attendance flags for Eventbrite

### DIFF
--- a/automations/eventbrite.yaml
+++ b/automations/eventbrite.yaml
@@ -114,9 +114,10 @@
         event_lines: |-
           {% for event in events %}
           {% set signups = event.ticket_classes | default([]) | map(attribute='quantity_sold') | map('int', default=0) | sum %}
+          {% set capacity = event.ticket_classes | default([]) | selectattr('quantity_total', 'defined') | map(attribute='quantity_total') | map('int', default=0) | sum %}
           *{{ event.name.text }}*
           :clock1: {{ event.start.local | as_datetime | timestamp_custom('%-I:%M %p') }}
-          :busts_in_silhouette: {{ signups }} signup{{ 's' if signups != 1 }}
+          {% if capacity > 0 and signups < (capacity * 0.5) %}:warning: Only {{ signups }} of {{ capacity }} spots filled — consider promoting this event{% else %}:busts_in_silhouette: {{ signups }}{% if capacity > 0 %} of {{ capacity }}{% endif %} spots filled{% endif %}
           :link: {{ event.url }}
           {% endfor %}
     - action: notify.make_nashville
@@ -124,6 +125,40 @@
         target: "#integrations_sandbox"
         message: |-
           :mega: *Events Today*
+          {{ event_lines }}
+        data:
+          username: Eventbrite
+          icon: calendar
+  mode: single
+
+- id: 'eventbrite_one_week_out'
+  alias: Eventbrite One Week Out
+  triggers:
+    - trigger: time
+      at: '09:00:00'
+  conditions:
+    - condition: template
+      value_template: >
+        {{ states('sensor.eventbrite_next_week_events') | int(0) > 0
+           and state_attr('sensor.eventbrite_next_week_events', 'events') is not none }}
+  actions:
+    - variables:
+        events: "{{ state_attr('sensor.eventbrite_next_week_events', 'events') }}"
+    - variables:
+        event_lines: |-
+          {% for event in events %}
+          {% set signups = event.ticket_classes | default([]) | map(attribute='quantity_sold') | map('int', default=0) | sum %}
+          {% set capacity = event.ticket_classes | default([]) | selectattr('quantity_total', 'defined') | map(attribute='quantity_total') | map('int', default=0) | sum %}
+          *{{ event.name.text }}*
+          :clock1: {{ event.start.local | as_datetime | timestamp_custom('%A, %B %-d at %-I:%M %p') }}
+          {% if capacity > 0 and signups < (capacity * 0.5) %}:warning: Only {{ signups }} of {{ capacity }} spots filled — consider promoting this event{% else %}:busts_in_silhouette: {{ signups }}{% if capacity > 0 %} of {{ capacity }}{% endif %} spots filled{% endif %}
+          :link: {{ event.url }}
+          {% endfor %}
+    - action: notify.make_nashville
+      data:
+        target: "#integrations_sandbox"
+        message: |-
+          :calendar: *One Week Out* — {{ states('sensor.eventbrite_next_week_events') }} upcoming event{{ 's' if states('sensor.eventbrite_next_week_events') | int(0) != 1 }}
           {{ event_lines }}
         data:
           username: Eventbrite

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -160,6 +160,16 @@ rest:
         value_template: "{{ (value_json.events | default([])) | length }}"
         json_attributes:
           - events
+  - resource_template: >-
+      https://www.eventbriteapi.com/v3/organizations/{{ states('input_text.eventbrite_org_id') }}/events/?start_date.range_start={{ (now() + timedelta(days=7)).strftime('%Y-%m-%dT00:00:00') }}&start_date.range_end={{ (now() + timedelta(days=7)).strftime('%Y-%m-%dT23:59:59') }}&expand=ticket_classes&status=live
+    headers:
+      Authorization: !secret eventbrite_token_header
+    scan_interval: 3600
+    sensor:
+      - name: Eventbrite Next Week Events
+        value_template: "{{ (value_json.events | default([])) | length }}"
+        json_attributes:
+          - events
 
 template:
   - sensor:


### PR DESCRIPTION
## Summary
- Adds new `eventbrite_next_week_events` REST sensor that fetches events starting 7 days from now with ticket class data
- Adds **Eventbrite One Week Out** automation — posts daily at 9am for events 7 days away, with signup/capacity info
- Enhances **Event Day Alert** to show signups vs. capacity and flag events under 50% capacity with a `:warning:` prompt to promote
- Events with unlimited ticket classes skip the low-attendance flag (no capacity to compare against)

## Test plan
- [ ] Verify `sensor.eventbrite_next_week_events` populates correctly with events 7 days out
- [ ] Verify One Week Out notification fires at 9am when events exist 7 days away
- [ ] Verify low-attendance flag appears when signups < 50% of capacity
- [ ] Verify healthy events show "X of Y spots filled" without warning
- [ ] Verify events with unlimited tickets show signup count without ratio or flag
- [ ] Verify Event Day Alert still fires at 8am with updated format

🤖 Generated with [Claude Code](https://claude.com/claude-code)