### PR TITLE
Fix Jinja2 scoping bug hiding names in signup digest

### DIFF
--- a/automations/eventbrite.yaml
+++ b/automations/eventbrite.yaml
@@ -72,19 +72,18 @@
             {% set ns.events = dict(ns.events, **{ename: names}) %}
           {% endfor %}
           {% for event, names in ns.events.items() %}
-            {%- set ns2 = namespace(counts={}) -%}
+            {%- set ns2 = namespace(counts={}, display=[]) -%}
             {%- for n in names -%}
               {%- set ns2.counts = dict(ns2.counts, **{n: ns2.counts.get(n, 0) + 1}) -%}
             {%- endfor -%}
-            {%- set display = [] -%}
             {%- for name, c in ns2.counts.items() -%}
               {%- if c > 1 -%}
-                {%- set display = display + [name ~ ' (' ~ c ~ ')'] -%}
+                {%- set ns2.display = ns2.display + [name ~ ' (' ~ c ~ ')'] -%}
               {%- else -%}
-                {%- set display = display + [name] -%}
+                {%- set ns2.display = ns2.display + [name] -%}
               {%- endif -%}
             {%- endfor %}
-          *{{ event }}* — {{ display | join(', ') }}
+          *{{ event }}* — {{ ns2.display | join(', ') }}
           {% endfor %}
     - action: notify.make_nashville
       data:


### PR DESCRIPTION
## Summary
- The dedup logic added in #77 used a plain `display` variable inside a Jinja2 `for` loop
- Jinja2 scopes `set` inside `for` blocks to the loop — so `display` reverted to `[]` after the loop, producing empty name lists
- Fixed by moving `display` to a namespace attribute (`ns2.display`) which persists across loop iterations

## Test plan
- [ ] Wait for next 9 AM digest with signups and verify names appear
- [ ] Confirm dedup still works (duplicate names show count suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)