### PR TITLE
Route notifications to appropriate Slack channels

### DIFF
--- a/automations/eventbrite.yaml
+++ b/automations/eventbrite.yaml
@@ -88,7 +88,7 @@
           {% endfor %}
     - action: notify.make_nashville
       data:
-        target: "#integrations_sandbox"
+        target: "#eventbrite-feed"
         message: |-
           :wave: *Eventbrite Signups — Last 24 Hours* ({{ count }} new)
           {{ event_lines }}

--- a/automations/health.yaml
+++ b/automations/health.yaml
@@ -17,7 +17,7 @@
     else:
     - action: notify.make_nashville
       data:
-        target: "#integrations_sandbox"
+        target: "#facilities-feed"
         message: ':white_check_mark: Home Assistant is online.'
         data:
           username: Home Assistant
@@ -66,7 +66,7 @@
   actions:
   - action: notify.make_nashville
     data:
-      target: "#integrations_sandbox"
+      target: "#facilities-feed"
       message: ':warning: Eventbrite integration may be down — sensor has been unavailable
         for 2+ hours. Check the API token.'
       data:

--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -396,6 +396,7 @@
   max: 4
 - id: 'hms_error_alert'
   alias: HMS Error Alert
+  enabled: false
   triggers:
   - entity_id:
     - binary_sensor.kiwi_hms_errors


### PR DESCRIPTION
## Summary
- Move daily signup digest to `#eventbrite-feed`
- Move HA online and Eventbrite stale warnings to `#facilities-feed`
- Disable HMS error alerts

## Test plan
- [ ] Verify daily signup digest posts to `#eventbrite-feed` at 9am
- [ ] Verify HA startup notification posts to `#facilities-feed`
- [ ] Verify Eventbrite stale warning posts to `#facilities-feed`
- [ ] Verify HMS error alert no longer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)