### PR TITLE
Refactor- Adjust facilities monitoring triggers and alerts for power

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -11,6 +11,7 @@
     below: 62
     for:
       minutes: 5
+
   - trigger: numeric_state
     entity_id:
     - sensor.air_quality_temperature
@@ -21,6 +22,7 @@
     above: 90
     for:
       minutes: 5
+
   - trigger: state
     id: temp_state_change
     entity_id:
@@ -29,15 +31,16 @@
     - sensor.woodshop_climate_sensor_temperature
     - sensor.front_hallway_climate_sensor_temperature
     - sensor.network_closet_climate_sensor_temperature
+
   - trigger: numeric_state
     entity_id: sensor.kaeser_monitor_system_pressure
     below: 80
     for:
       minutes: 5
-  - trigger: state
-    entity_id: sensor.total_power_alarm_power_failure_alarm
+
   - trigger: state
     entity_id: binary_sensor.water_leak_sensor
+
   conditions:
   - condition: template
     value_template: >
@@ -58,12 +61,12 @@
       {% set allowed_non_temp = (
         trigger.platform == 'numeric_state' or
         trigger.entity_id in [
-          'sensor.total_power_alarm_power_failure_alarm',
           'binary_sensor.water_leak_sensor'
         ]
       ) %}
 
       {{ cooldown_ok and (allowed_non_temp or valid_temp_change) }}
+
   actions:
   - action: notify.make_nashville
     data:
@@ -75,8 +78,8 @@
         :warning: *Facilities Alert* — {{ trigger.to_state.name }} {{ trigger.to_state.state }}{{ trigger.to_state.attributes.unit_of_measurement | default('') }}
         *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
 
-        *:thermometer: Climate*
-        {% set ns = namespace(count=0, unavail=[]) -%}
+        *:thermometer: Environment*
+        {% set ns = namespace(count=0) -%}
         {% for device_id in label_devices('facilities_pulse') -%}
         {% set entities = device_entities(device_id) -%}
         {% set temp_e = entities | reject('search','display_temperature') | select('search','temperature') | first | default(none) -%}
@@ -86,50 +89,97 @@
         {% set t = states(temp_e) | float(0) -%}
         {% set icon = ':green_circle:' if t >= 65 and t <= 80 else ':yellow_circle:' if t >= 60 and t < 65 or t > 80 and t <= 85 else ':red_circle:' -%}
         {{ icon }} {{ "%.1f°F"|format(t) }}  {{ "%-17s"|format(area_name(temp_e)|default('Unknown')) }} {{ states(hum_e)|float(0)|round(0)|int }}%
-        {% elif temp_e -%}
-        {% set ns.unavail = ns.unavail + [area_name(temp_e)|default('Unknown')] -%}
         {% endif -%}
         {% endfor -%}
-        {% if ns.count == 0 and not ns.unavail %}:warning: No sensors found — check the facilities_pulse label{% endif -%}
+        {% if ns.count == 0 %}:warning: No sensors found — check the facilities_pulse label{% endif -%}
         :partly_sunny: {{ "%.1f°F"|format(state_attr('weather.forecast_home','temperature')|float(0)) }}  {{ "%-17s"|format('Outside') }} {{ state_attr('weather.forecast_home','humidity')|int }}%
 
         *:gear: Systems*
         {% set pwr = states('sensor.total_power_alarm_power_failure_alarm') | lower -%}
-        {% if pwr not in ['unknown','unavailable'] -%}
-        {{ ':green_circle:' if pwr == 'normal' else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
-        {% else -%}
-        {% set ns.unavail = ns.unavail + ['Power'] -%}
-        {% endif -%}
+        {{ ':green_circle:' if pwr in ['ok', 'normal'] else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
         {% set leak = states('binary_sensor.water_leak_sensor') -%}
-        {% if leak not in ['unknown','unavailable'] -%}
         {{ ':green_circle:' if leak == 'off' else ':red_circle:' }} {{ "%-14s"|format(state_translated('binary_sensor.water_leak_sensor')) }}  Exec Bathroom
-        {% else -%}
-        {% set ns.unavail = ns.unavail + ['Exec Bathroom Water'] -%}
-        {% endif -%}
-        {% set kpsi_raw = states('sensor.kaeser_monitor_system_pressure') -%}
-        {% if kpsi_raw not in ['unknown','unavailable'] -%}
-        {% set kpsi = kpsi_raw | float(0) -%}
+        {% set kpsi = states('sensor.kaeser_monitor_system_pressure') | float(0) -%}
         {{ ':green_circle:' if kpsi >= 80 else ':red_circle:' }} {{ "%-14s"|format(kpsi | round(1) | string ~ ' psi') }}  Kaeser
-        {% else -%}
-        {% set ns.unavail = ns.unavail + ['Kaeser'] -%}
-        {% endif %}
 
-        *:dash: Air Quality*
+        *:dash: 3D Print Room*
         {% set aq = states('sensor.air_quality_overall_status') -%}
-        {% if aq not in ['unknown','unavailable'] -%}
         {% set aq_icon = ':green_circle:' if aq == 'Good' else ':yellow_circle:' if aq == 'Moderate' else ':large_orange_circle:' if aq == 'Poor' else ':red_circle:' -%}
-        {{ aq_icon }} 3D Printing: {{ aq }}
+        {{ aq_icon }} Air Quality: {{ aq }}
         CO₂: {{ states('sensor.air_quality_carbon_dioxide') }} ppm  |  VOC: {{ states('sensor.air_quality_voc_index') }}  |  PM2.5: {{ states('sensor.air_quality_pm2_5') | float(0) | round(1) }} ug/m3
-        {% else -%}
-        {% set ns.unavail = ns.unavail + ['Air Quality'] -%}
-        {% endif -%}
-
-        {% if ns.unavail -%}
-        *:grey_question: Unavailable*
-        {{ ns.unavail | join(', ') }}
-        {% endif -%}
   mode: queued
   max: 2
+
+- id: facilities_pulse_power_outage
+  alias: Facilities Pulse — Power Outage
+  description: Notify when facility power goes into alarm
+  triggers:
+  - trigger: state
+    entity_id: sensor.total_power_alarm_power_failure_alarm
+    to: "Alert"
+  conditions:
+  - condition: template
+    value_template: >
+      {{ trigger.from_state is not none and
+         trigger.to_state is not none and
+         trigger.from_state.state not in ['unknown', 'unavailable', none] and
+         trigger.to_state.state not in ['unknown', 'unavailable', none] }}
+  actions:
+  - action: notify.make_nashville
+    data:
+      target: "#facilities-feed"
+      data:
+        username: Facilities Pulse
+        icon: warning
+      message: |
+        :rotating_light: *POWER OUTAGE ALERT*
+        Power monitor changed to *{{ trigger.to_state.state }}*.
+        *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
+
+        *:gear: Systems Snapshot*
+        {% set pwr = states('sensor.total_power_alarm_power_failure_alarm') | lower -%}
+        {{ ':green_circle:' if pwr in ['ok', 'normal'] else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
+        {% set leak = states('binary_sensor.water_leak_sensor') -%}
+        {{ ':green_circle:' if leak == 'off' else ':red_circle:' }} {{ "%-14s"|format(state_translated('binary_sensor.water_leak_sensor')) }}  Exec Bathroom
+        {% set kpsi = states('sensor.kaeser_monitor_system_pressure') | float(0) -%}
+        {{ ':green_circle:' if kpsi >= 80 else ':red_circle:' }} {{ "%-14s"|format(kpsi | round(1) | string ~ ' psi') }}  Kaeser
+  mode: single
+
+- id: facilities_pulse_power_restored
+  alias: Facilities Pulse — Power Restored
+  description: Notify when facility power returns to normal
+  triggers:
+  - trigger: state
+    entity_id: sensor.total_power_alarm_power_failure_alarm
+    to: "Normal"
+  conditions:
+  - condition: template
+    value_template: >
+      {{ trigger.from_state is not none and
+         trigger.to_state is not none and
+         trigger.from_state.state not in ['unknown', 'unavailable', none] and
+         trigger.to_state.state not in ['unknown', 'unavailable', none] }}
+  actions:
+  - action: notify.make_nashville
+    data:
+      target: "#facilities-feed"
+      data:
+        username: Facilities Pulse
+        icon: electric_plug
+      message: |
+        :white_check_mark: *POWER RESTORED*
+        Power monitor changed to *{{ trigger.to_state.state }}*.
+        *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
+
+        *:gear: Systems Snapshot*
+        {% set pwr = states('sensor.total_power_alarm_power_failure_alarm') | lower -%}
+        {{ ':green_circle:' if pwr in ['ok', 'normal'] else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
+        {% set leak = states('binary_sensor.water_leak_sensor') -%}
+        {{ ':green_circle:' if leak == 'off' else ':red_circle:' }} {{ "%-14s"|format(state_translated('binary_sensor.water_leak_sensor')) }}  Exec Bathroom
+        {% set kpsi = states('sensor.kaeser_monitor_system_pressure') | float(0) -%}
+        {{ ':green_circle:' if kpsi >= 80 else ':red_circle:' }} {{ "%-14s"|format(kpsi | round(1) | string ~ ' psi') }}  Kaeser
+  mode: single
+
 - id: facilities_pulse_verbose
   alias: Facilities Pulse — Verbose
   triggers:
@@ -148,8 +198,8 @@
       message: |
         *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
 
-        *:thermometer: Climate*
-        {% set ns = namespace(count=0, unavail=[]) -%}
+        *:thermometer: Environment*
+        {% set ns = namespace(count=0) -%}
         {% for device_id in label_devices('facilities_pulse') -%}
         {% set entities = device_entities(device_id) -%}
         {% set temp_e = entities | reject('search','display_temperature') | select('search','temperature') | first | default(none) -%}
@@ -159,49 +209,26 @@
         {% set t = states(temp_e) | float(0) -%}
         {% set icon = ':green_circle:' if t >= 65 and t <= 80 else ':yellow_circle:' if t >= 60 and t < 65 or t > 80 and t <= 85 else ':red_circle:' -%}
         {{ icon }} {{ "%.1f°F"|format(t) }}  {{ "%-17s"|format(area_name(temp_e)|default('Unknown')) }} {{ states(hum_e)|float(0)|round(0)|int }}%
-        {% elif temp_e -%}
-        {% set ns.unavail = ns.unavail + [area_name(temp_e)|default('Unknown')] -%}
         {% endif -%}
         {% endfor -%}
-        {% if ns.count == 0 and not ns.unavail %}:warning: No sensors found — check the facilities_pulse label{% endif -%}
+        {% if ns.count == 0 %}:warning: No sensors found — check the facilities_pulse label{% endif -%}
         :partly_sunny: {{ "%.1f°F"|format(state_attr('weather.forecast_home','temperature')|float(0)) }}  {{ "%-17s"|format('Outside') }} {{ state_attr('weather.forecast_home','humidity')|int }}%
 
         *:gear: Systems*
         {% set pwr = states('sensor.total_power_alarm_power_failure_alarm') | lower -%}
-        {% if pwr not in ['unknown','unavailable'] -%}
-        {{ ':green_circle:' if pwr == 'normal' else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
-        {% else -%}
-        {% set ns.unavail = ns.unavail + ['Power'] -%}
-        {% endif -%}
+        {{ ':green_circle:' if pwr in ['ok', 'normal'] else ':red_circle:' }} {{ "%-14s"|format(pwr | capitalize) }}  Power
         {% set leak = states('binary_sensor.water_leak_sensor') -%}
-        {% if leak not in ['unknown','unavailable'] -%}
         {{ ':green_circle:' if leak == 'off' else ':red_circle:' }} {{ "%-14s"|format(state_translated('binary_sensor.water_leak_sensor')) }}  Exec Bathroom
-        {% else -%}
-        {% set ns.unavail = ns.unavail + ['Exec Bathroom Water'] -%}
-        {% endif -%}
-        {% set kpsi_raw = states('sensor.kaeser_monitor_system_pressure') -%}
-        {% if kpsi_raw not in ['unknown','unavailable'] -%}
-        {% set kpsi = kpsi_raw | float(0) -%}
+        {% set kpsi = states('sensor.kaeser_monitor_system_pressure') | float(0) -%}
         {{ ':green_circle:' if kpsi >= 80 else ':red_circle:' }} {{ "%-14s"|format(kpsi | round(1) | string ~ ' psi') }}  Kaeser
-        {% else -%}
-        {% set ns.unavail = ns.unavail + ['Kaeser'] -%}
-        {% endif %}
 
-        *:dash: Air Quality*
+        *:dash: 3D Print Room*
         {% set aq = states('sensor.air_quality_overall_status') -%}
-        {% if aq not in ['unknown','unavailable'] -%}
         {% set aq_icon = ':green_circle:' if aq == 'Good' else ':yellow_circle:' if aq == 'Moderate' else ':large_orange_circle:' if aq == 'Poor' else ':red_circle:' -%}
-        {{ aq_icon }} 3D Printing: {{ aq }}
+        {{ aq_icon }} Air Quality: {{ aq }}
         CO₂: {{ states('sensor.air_quality_carbon_dioxide') }} ppm  |  VOC: {{ states('sensor.air_quality_voc_index') }}  |  PM2.5: {{ states('sensor.air_quality_pm2_5') | float(0) | round(1) }} ug/m3
-        {% else -%}
-        {% set ns.unavail = ns.unavail + ['Air Quality'] -%}
-        {% endif -%}
-
-        {% if ns.unavail -%}
-        *:grey_question: Unavailable*
-        {{ ns.unavail | join(', ') }}
-        {% endif -%}
   mode: single
+
 - id: '1740600000002'
   alias: Air Quality Alert
   description: Notify #integration-sandbox when 3D print room air quality degrades or recovers


### PR DESCRIPTION
Updated triggers and notifications for facilities monitoring, including changes to power alerts.  
The main change is that  
 -  sensor.total_power_alarm_power_failure_alarm is no longer a trigger inside facilities_pulse_smart_alert  
 - so power won’t get mixed into the generic facilities logic anymore.  
 - I also updated the power status display in both message templates from: pwr == 'ok' to pwr in ['ok', 'normal']. That helps in case the entity reports Normal when power is healthy.