### PR TITLE
Fix Slack threading for printer notifications

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -209,7 +209,7 @@
     target:
       entity_id: "input_text.{{ printer }}_slack_thread_ts"
     data:
-      value: "{% set ts = slack_response['content']['ts'] | default('') | string %}{{ ts if '.' in ts else '' }}"
+      value: "{% set ts = (slack_response['content'] | from_json).ts | default('') | string %}{{ ts if '.' in ts else '' }}"
   - if:
     - condition: template
       value_template: "{{ printer == 'pineapple' }}"


### PR DESCRIPTION
## Summary
- `rest_command` returns response `content` as a raw JSON string, not a parsed dict
- `slack_response['content']['ts']` silently failed (caught by `| default('')`), leaving the `input_text.{printer}_slack_thread_ts` helper empty
- All printer lifecycle messages (progress, finished, stopped, error, paused, resumed) posted as top-level messages instead of threaded replies
- Fix: parse the response with `from_json` before accessing `.ts`

## Test plan
- [ ] Start a print and confirm the "Print Starting" message posts to `#3dprint-info`
- [ ] Verify `input_text.{printer}_slack_thread_ts` gets populated with a valid timestamp (contains a `.`)
- [ ] Confirm subsequent lifecycle messages (progress, finished) appear as threaded replies under the starting message

🤖 Generated with [Claude Code](https://claude.com/claude-code)