### PR TITLE
Add Energy Monitor dashboard for Shelly Pro 3EM

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -29,6 +29,13 @@ lovelace:
       filename: dashboards/facilities.yaml
       show_in_sidebar: true
       require_admin: false
+    energy-monitor:
+      mode: yaml
+      title: Energy Monitor
+      icon: mdi:lightning-bolt
+      filename: dashboards/energy.yaml
+      show_in_sidebar: true
+      require_admin: false
 
 shell_command:
   git_pull: "git -C /config pull --rebase origin main"

--- a/dashboards/energy.yaml
+++ b/dashboards/energy.yaml
@@ -1,0 +1,234 @@
+title: Energy Monitor
+views:
+  - title: Energy Monitor
+    path: overview
+    icon: mdi:lightning-bolt
+    cards:
+
+      # ── Status header ─────────────────────────────────────────────────────
+      - type: markdown
+        content: >
+          {% set total = states('sensor.pro3em_1_power') | float(0) %}
+          {% set icon = '🟢' if total < 20000 else '🟡' if total < 27000 else '🔴' %}
+          ## {{ icon }} ⚡ Energy Monitor — **{{ now().strftime('%-I:%M %p') }}**
+
+          Total load: **{{ (total / 1000) | round(2) }} kW**
+          {%- if total >= 27000 %} — ⚠️ HIGH LOAD{% endif %}
+
+      # ── Total power gauge ─────────────────────────────────────────────────
+      - type: gauge
+        entity: sensor.pro3em_1_power
+        name: Total Power
+        unit: W
+        min: 0
+        max: 30000
+        needle: true
+        severity:
+          green: 0
+          yellow: 20000
+          red: 27000
+
+      # ── Per-phase power ───────────────────────────────────────────────────
+      - type: grid
+        columns: 3
+        square: false
+        cards:
+          - type: gauge
+            entity: sensor.pro3em_1_phase_a_power
+            name: Phase A — Power
+            unit: W
+            min: 0
+            max: 10000
+            needle: true
+            severity:
+              green: 0
+              yellow: 7000
+              red: 9000
+
+          - type: gauge
+            entity: sensor.pro3em_1_phase_b_power
+            name: Phase B — Power
+            unit: W
+            min: 0
+            max: 10000
+            needle: true
+            severity:
+              green: 0
+              yellow: 7000
+              red: 9000
+
+          - type: gauge
+            entity: sensor.pro3em_1_phase_c_power
+            name: Phase C — Power
+            unit: W
+            min: 0
+            max: 10000
+            needle: true
+            severity:
+              green: 0
+              yellow: 7000
+              red: 9000
+
+      # ── Per-phase current ─────────────────────────────────────────────────
+      - type: grid
+        columns: 3
+        square: false
+        cards:
+          - type: gauge
+            entity: sensor.pro3em_1_phase_a_current
+            name: Phase A — Current
+            unit: A
+            min: 0
+            max: 400
+            needle: true
+            severity:
+              green: 0
+              yellow: 280
+              red: 360
+
+          - type: gauge
+            entity: sensor.pro3em_1_phase_b_current
+            name: Phase B — Current
+            unit: A
+            min: 0
+            max: 400
+            needle: true
+            severity:
+              green: 0
+              yellow: 280
+              red: 360
+
+          - type: gauge
+            entity: sensor.pro3em_1_phase_c_current
+            name: Phase C — Current
+            unit: A
+            min: 0
+            max: 400
+            needle: true
+            severity:
+              green: 0
+              yellow: 280
+              red: 360
+
+      # ── Per-phase voltage ─────────────────────────────────────────────────
+      - type: grid
+        columns: 3
+        square: false
+        cards:
+          - type: gauge
+            entity: sensor.pro3em_1_phase_a_voltage
+            name: Phase A — Voltage
+            unit: V
+            min: 100
+            max: 130
+            needle: true
+            severity:
+              green: 114
+              yellow: 108
+              red: 100
+
+          - type: gauge
+            entity: sensor.pro3em_1_phase_b_voltage
+            name: Phase B — Voltage
+            unit: V
+            min: 100
+            max: 130
+            needle: true
+            severity:
+              green: 114
+              yellow: 108
+              red: 100
+
+          - type: gauge
+            entity: sensor.pro3em_1_phase_c_voltage
+            name: Phase C — Voltage
+            unit: V
+            min: 100
+            max: 130
+            needle: true
+            severity:
+              green: 114
+              yellow: 108
+              red: 100
+
+      # ── Glance summary ────────────────────────────────────────────────────
+      - type: glance
+        title: All Readings
+        columns: 3
+        entities:
+          - entity: sensor.pro3em_1_phase_a_power
+            name: A · Watts
+          - entity: sensor.pro3em_1_phase_a_current
+            name: A · Amps
+          - entity: sensor.pro3em_1_phase_a_voltage
+            name: A · Volts
+          - entity: sensor.pro3em_1_phase_b_power
+            name: B · Watts
+          - entity: sensor.pro3em_1_phase_b_current
+            name: B · Amps
+          - entity: sensor.pro3em_1_phase_b_voltage
+            name: B · Volts
+          - entity: sensor.pro3em_1_phase_c_power
+            name: C · Watts
+          - entity: sensor.pro3em_1_phase_c_current
+            name: C · Amps
+          - entity: sensor.pro3em_1_phase_c_voltage
+            name: C · Volts
+
+      # ── 24-hour history ───────────────────────────────────────────────────
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: history-graph
+            title: Power — 24h (W)
+            hours_to_show: 24
+            entities:
+              - entity: sensor.pro3em_1_power
+                name: Total
+              - entity: sensor.pro3em_1_phase_a_power
+                name: Phase A
+              - entity: sensor.pro3em_1_phase_b_power
+                name: Phase B
+              - entity: sensor.pro3em_1_phase_c_power
+                name: Phase C
+
+          - type: history-graph
+            title: Voltage — 24h (V)
+            hours_to_show: 24
+            entities:
+              - entity: sensor.pro3em_1_phase_a_voltage
+                name: Phase A
+              - entity: sensor.pro3em_1_phase_b_voltage
+                name: Phase B
+              - entity: sensor.pro3em_1_phase_c_voltage
+                name: Phase C
+
+      # ── 2-week history ────────────────────────────────────────────────────
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: history-graph
+            title: Power — 2 weeks (W)
+            hours_to_show: 336
+            entities:
+              - entity: sensor.pro3em_1_power
+                name: Total
+              - entity: sensor.pro3em_1_phase_a_power
+                name: Phase A
+              - entity: sensor.pro3em_1_phase_b_power
+                name: Phase B
+              - entity: sensor.pro3em_1_phase_c_power
+                name: Phase C
+
+          - type: history-graph
+            title: Current — 2 weeks (A)
+            hours_to_show: 336
+            entities:
+              - entity: sensor.pro3em_1_phase_a_current
+                name: Phase A
+              - entity: sensor.pro3em_1_phase_b_current
+                name: Phase B
+              - entity: sensor.pro3em_1_phase_c_current
+                name: Phase C


### PR DESCRIPTION
## Summary

- Adds `dashboards/energy.yaml` — new Lovelace YAML dashboard for the Shelly Pro 3EM 3-phase energy monitor
- Registers it as `energy-monitor` in `configuration.yaml` (sidebar title: **Energy Monitor**, icon: `mdi:lightning-bolt`)

**Dashboard sections:**
- Header with total load in kW and high-load warning
- Total power gauge (0–30 kW)
- Per-phase power gauges — A, B, C (0–10 kW each)
- Per-phase current gauges — A, B, C (0–400 A)
- Per-phase voltage gauges — A, B, C (100–130 V, with under-voltage severity)
- Glance card with all 9 readings at a glance
- 24h history graphs — power (all phases + total) and voltage
- 2-week history graphs — power (all phases + total) and current

## Test plan

- [ ] YAML validation passes in CI
- [ ] After deploy, "Energy Monitor" appears in HA sidebar
- [ ] All gauges show live values (not `unavailable`)
- [ ] History graphs populate after a few minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)