### PR TITLE
Fix Slack threading for printer lifecycle notifications

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -82,79 +82,30 @@
         {%- set flavor = 'almost done!' if prog >= 90 else ('halfway there!' if prog >= 50 else 'printing away!') -%}
         :speech_balloon: {{ states('sensor.' + printer + '_print_progress', with_unit=True) }}
         {%- if time_str %} | {{ time_str }}{% endif %} — {{ owner }}{{ object_name }} {{ flavor }} <{{ states('input_text.' + printer + '_stream') }}|Camera Feed>
-  - choose:
-    - conditions:
-      - condition: template
-        value_template: "{{ '.' in thread_ts }}"
-      sequence:
-      - data:
-          target: "#3dprint-info"
-          message: "{{ progress_msg }}"
-          data:
-            username: '{{ printer | capitalize }}'
-            icon: "{{ icon_name }}"
-            thread_ts: '{{ thread_ts }}'
-            blocks:
-            - type: section
-              text:
-                type: mrkdwn
-                text: "{{ progress_msg }}"
-            - type: actions
-              elements:
-              - type: button
-                text:
-                  type: plain_text
-                  text: "Pause Print"
-                action_id: pause_bambu_print
-                value: "{{ printer }}"
-                confirm:
-                  title:
-                    type: plain_text
-                    text: "Pause Print?"
-                  text:
-                    type: mrkdwn
-                    text: "This will pause the current print. Are you sure?"
-                  confirm:
-                    type: plain_text
-                    text: "Yes, pause it"
-                  deny:
-                    type: plain_text
-                    text: "Never mind"
-        action: notify.make_nashville
-    default:
-    - data:
-        target: "#3dprint-info"
-        message: "{{ progress_msg }}"
-        data:
-          username: '{{ printer | capitalize }}'
-          icon: "{{ icon_name }}"
-          blocks:
-          - type: section
-            text:
-              type: mrkdwn
-              text: "{{ progress_msg }}"
-          - type: actions
-            elements:
-            - type: button
-              text:
-                type: plain_text
-                text: "Pause Print"
-              action_id: pause_bambu_print
-              value: "{{ printer }}"
-              confirm:
-                title:
-                  type: plain_text
-                  text: "Pause Print?"
-                text:
-                  type: mrkdwn
-                  text: "This will pause the current print. Are you sure?"
-                confirm:
-                  type: plain_text
-                  text: "Yes, pause it"
-                deny:
-                  type: plain_text
-                  text: "Never mind"
-      action: notify.make_nashville
+  - variables:
+      is_bambu: "{{ printer in ['kiwi','mango','papaya','strawberry','huckleberry'] }}"
+      blocks: >-
+        {%- if is_bambu -%}
+        [{"type": "section", "text": {"type": "mrkdwn", "text": {{ progress_msg | tojson }}}},
+        {"type": "actions", "elements":
+        [{"type": "button",
+        "text": {"type": "plain_text", "text": "Pause Print"},
+        "action_id": "pause_bambu_print",
+        "value": "{{ printer }}",
+        "confirm": {
+        "title": {"type": "plain_text", "text": "Pause Print?"},
+        "text": {"type": "mrkdwn", "text": "This will pause the current print. Are you sure?"},
+        "confirm": {"type": "plain_text", "text": "Yes, pause it"},
+        "deny": {"type": "plain_text", "text": "Never mind"}}}]}]
+        {%- endif -%}
+  - action: rest_command.slack_post_3dprint
+    data:
+      channel: "#3dprint-info"
+      text: "{{ progress_msg }}"
+      username: "{{ printer | capitalize }}"
+      icon_emoji: ":{{ icon_name }}:"
+      blocks: "{{ blocks }}"
+      thread_ts: "{{ thread_ts }}"
   mode: single
 - id: '1722144402850'
   alias: Lifecycle Print Starting
@@ -312,27 +263,13 @@
         {%- set owner = '@' ~ display_name ~ ', ' if display_name != object_name else '' -%}
         :white_check_mark: 100% | {{ job_time_str }}
         {%- if used_weight %} | {{ used_weight }}{% endif %} — {{ owner }}{{ object_name }} is done! Come grab it and clear the plate for the next maker. <{{ states('input_text.' + printer + '_stream') }}|Camera Feed>
-  - choose:
-    - conditions:
-      - condition: template
-        value_template: "{{ '.' in thread_ts }}"
-      sequence:
-      - data:
-          target: "#3dprint-info"
-          message: "{{ finished_msg }}"
-          data:
-            username: '{{ printer | capitalize }}'
-            icon: "{{ icon_name }}"
-            thread_ts: '{{ thread_ts }}'
-        action: notify.make_nashville
-    default:
-    - data:
-        target: "#3dprint-info"
-        message: "{{ finished_msg }}"
-        data:
-          username: '{{ printer | capitalize }}'
-          icon: "{{ icon_name }}"
-      action: notify.make_nashville
+  - action: rest_command.slack_post_3dprint
+    data:
+      channel: "#3dprint-info"
+      text: "{{ finished_msg }}"
+      username: "{{ printer | capitalize }}"
+      icon_emoji: ":{{ icon_name }}:"
+      thread_ts: "{{ thread_ts }}"
   - action: input_text.set_value
     target:
       entity_id: "input_text.{{ printer }}_slack_thread_ts"
@@ -373,27 +310,13 @@
       stopped_msg: |-
         {%- set owner = '@' ~ display_name ~ ', ' if display_name != object_name else '' -%}
         :octagonal_sign: {{ progress }}% — {{ owner }}{{ object_name }} stopped mid-print. Come take a look and see what happened. <{{ states('input_text.' + printer + '_stream') }}|Camera Feed>
-  - choose:
-    - conditions:
-      - condition: template
-        value_template: "{{ '.' in thread_ts }}"
-      sequence:
-      - data:
-          target: "#3dprint-info"
-          message: "{{ stopped_msg }}"
-          data:
-            username: '{{ printer | capitalize }}'
-            icon: "{{ icon_name }}"
-            thread_ts: '{{ thread_ts }}'
-        action: notify.make_nashville
-    default:
-    - data:
-        target: "#3dprint-info"
-        message: "{{ stopped_msg }}"
-        data:
-          username: '{{ printer | capitalize }}'
-          icon: "{{ icon_name }}"
-      action: notify.make_nashville
+  - action: rest_command.slack_post_3dprint
+    data:
+      channel: "#3dprint-info"
+      text: "{{ stopped_msg }}"
+      username: "{{ printer | capitalize }}"
+      icon_emoji: ":{{ icon_name }}:"
+      thread_ts: "{{ thread_ts }}"
   - action: input_text.set_value
     target:
       entity_id: "input_text.{{ printer }}_slack_thread_ts"
@@ -434,27 +357,13 @@
         {%- set owner = '@' ~ display_name ~ ', ' if display_name != object_name else '' -%}
         :rotating_light:
         {%- if error_info %} {{ error_info }} —{% endif %} {{ owner }}{{ object_name }} hit a snag. Head over and check on it. <{{ states('input_text.' + printer + '_stream') }}|Camera Feed>
-  - choose:
-    - conditions:
-      - condition: template
-        value_template: "{{ '.' in thread_ts }}"
-      sequence:
-      - data:
-          target: "#3dprint-info"
-          message: "{{ error_msg }}"
-          data:
-            username: '{{ printer | capitalize }}'
-            icon: "{{ icon_name }}"
-            thread_ts: '{{ thread_ts }}'
-        action: notify.make_nashville
-    default:
-    - data:
-        target: "#3dprint-info"
-        message: "{{ error_msg }}"
-        data:
-          username: '{{ printer | capitalize }}'
-          icon: "{{ icon_name }}"
-      action: notify.make_nashville
+  - action: rest_command.slack_post_3dprint
+    data:
+      channel: "#3dprint-info"
+      text: "{{ error_msg }}"
+      username: "{{ printer | capitalize }}"
+      icon_emoji: ":{{ icon_name }}:"
+      thread_ts: "{{ thread_ts }}"
   mode: parallel
   max: 4
 - id: 'hms_error_alert'
@@ -554,79 +463,30 @@
         {%- set owner = '@' ~ display_name ~ ', ' if display_name != object_name else '' -%}
         :double_vertical_bar: {{ progress }}%
         {%- if time_str %} | {{ time_str }}{% endif %} — {{ owner }}{{ object_name }} is on hold. Head over when you get a chance! <{{ states('input_text.' + printer + '_stream') }}|Camera Feed>
-  - choose:
-    - conditions:
-      - condition: template
-        value_template: "{{ '.' in thread_ts }}"
-      sequence:
-      - data:
-          target: "#3dprint-info"
-          message: "{{ paused_msg }}"
-          data:
-            username: '{{ printer | capitalize }}'
-            icon: "{{ icon_name }}"
-            thread_ts: '{{ thread_ts }}'
-            blocks:
-            - type: section
-              text:
-                type: mrkdwn
-                text: "{{ paused_msg }}"
-            - type: actions
-              elements:
-              - type: button
-                text:
-                  type: plain_text
-                  text: "Resume Print"
-                action_id: resume_bambu_print
-                value: "{{ printer }}"
-                confirm:
-                  title:
-                    type: plain_text
-                    text: "Resume Print?"
-                  text:
-                    type: mrkdwn
-                    text: "This will resume the paused print. Are you sure?"
-                  confirm:
-                    type: plain_text
-                    text: "Yes, resume it"
-                  deny:
-                    type: plain_text
-                    text: "Never mind"
-        action: notify.make_nashville
-    default:
-    - data:
-        target: "#3dprint-info"
-        message: "{{ paused_msg }}"
-        data:
-          username: '{{ printer | capitalize }}'
-          icon: "{{ icon_name }}"
-          blocks:
-          - type: section
-            text:
-              type: mrkdwn
-              text: "{{ paused_msg }}"
-          - type: actions
-            elements:
-            - type: button
-              text:
-                type: plain_text
-                text: "Resume Print"
-              action_id: resume_bambu_print
-              value: "{{ printer }}"
-              confirm:
-                title:
-                  type: plain_text
-                  text: "Resume Print?"
-                text:
-                  type: mrkdwn
-                  text: "This will resume the paused print. Are you sure?"
-                confirm:
-                  type: plain_text
-                  text: "Yes, resume it"
-                deny:
-                  type: plain_text
-                  text: "Never mind"
-      action: notify.make_nashville
+  - variables:
+      is_bambu: "{{ printer in ['kiwi','mango','papaya','strawberry','huckleberry'] }}"
+      blocks: >-
+        {%- if is_bambu -%}
+        [{"type": "section", "text": {"type": "mrkdwn", "text": {{ paused_msg | tojson }}}},
+        {"type": "actions", "elements":
+        [{"type": "button",
+        "text": {"type": "plain_text", "text": "Resume Print"},
+        "action_id": "resume_bambu_print",
+        "value": "{{ printer }}",
+        "confirm": {
+        "title": {"type": "plain_text", "text": "Resume Print?"},
+        "text": {"type": "mrkdwn", "text": "This will resume the paused print. Are you sure?"},
+        "confirm": {"type": "plain_text", "text": "Yes, resume it"},
+        "deny": {"type": "plain_text", "text": "Never mind"}}}]}]
+        {%- endif -%}
+  - action: rest_command.slack_post_3dprint
+    data:
+      channel: "#3dprint-info"
+      text: "{{ paused_msg }}"
+      username: "{{ printer | capitalize }}"
+      icon_emoji: ":{{ icon_name }}:"
+      blocks: "{{ blocks }}"
+      thread_ts: "{{ thread_ts }}"
   mode: parallel
   max: 4
 - id: '1740400002000'
@@ -672,79 +532,30 @@
         {%- set owner = '@' ~ display_name ~ ', ' if display_name != object_name else '' -%}
         :arrow_forward: {{ progress }}%
         {%- if time_str %} | {{ time_str }}{% endif %} — {{ owner }}{{ object_name }} is back at it! <{{ states('input_text.' + printer + '_stream') }}|Camera Feed>
-  - choose:
-    - conditions:
-      - condition: template
-        value_template: "{{ '.' in thread_ts }}"
-      sequence:
-      - data:
-          target: "#3dprint-info"
-          message: "{{ resumed_msg }}"
-          data:
-            username: '{{ printer | capitalize }}'
-            icon: "{{ icon_name }}"
-            thread_ts: '{{ thread_ts }}'
-            blocks:
-            - type: section
-              text:
-                type: mrkdwn
-                text: "{{ resumed_msg }}"
-            - type: actions
-              elements:
-              - type: button
-                text:
-                  type: plain_text
-                  text: "Pause Print"
-                action_id: pause_bambu_print
-                value: "{{ printer }}"
-                confirm:
-                  title:
-                    type: plain_text
-                    text: "Pause Print?"
-                  text:
-                    type: mrkdwn
-                    text: "This will pause the current print. Are you sure?"
-                  confirm:
-                    type: plain_text
-                    text: "Yes, pause it"
-                  deny:
-                    type: plain_text
-                    text: "Never mind"
-        action: notify.make_nashville
-    default:
-    - data:
-        target: "#3dprint-info"
-        message: "{{ resumed_msg }}"
-        data:
-          username: '{{ printer | capitalize }}'
-          icon: "{{ icon_name }}"
-          blocks:
-          - type: section
-            text:
-              type: mrkdwn
-              text: "{{ resumed_msg }}"
-          - type: actions
-            elements:
-            - type: button
-              text:
-                type: plain_text
-                text: "Pause Print"
-              action_id: pause_bambu_print
-              value: "{{ printer }}"
-              confirm:
-                title:
-                  type: plain_text
-                  text: "Pause Print?"
-                text:
-                  type: mrkdwn
-                  text: "This will pause the current print. Are you sure?"
-                confirm:
-                  type: plain_text
-                  text: "Yes, pause it"
-                deny:
-                  type: plain_text
-                  text: "Never mind"
-      action: notify.make_nashville
+  - variables:
+      is_bambu: "{{ printer in ['kiwi','mango','papaya','strawberry','huckleberry'] }}"
+      blocks: >-
+        {%- if is_bambu -%}
+        [{"type": "section", "text": {"type": "mrkdwn", "text": {{ resumed_msg | tojson }}}},
+        {"type": "actions", "elements":
+        [{"type": "button",
+        "text": {"type": "plain_text", "text": "Pause Print"},
+        "action_id": "pause_bambu_print",
+        "value": "{{ printer }}",
+        "confirm": {
+        "title": {"type": "plain_text", "text": "Pause Print?"},
+        "text": {"type": "mrkdwn", "text": "This will pause the current print. Are you sure?"},
+        "confirm": {"type": "plain_text", "text": "Yes, pause it"},
+        "deny": {"type": "plain_text", "text": "Never mind"}}}]}]
+        {%- endif -%}
+  - action: rest_command.slack_post_3dprint
+    data:
+      channel: "#3dprint-info"
+      text: "{{ resumed_msg }}"
+      username: "{{ printer | capitalize }}"
+      icon_emoji: ":{{ icon_name }}:"
+      blocks: "{{ blocks }}"
+      thread_ts: "{{ thread_ts }}"
   mode: parallel
   max: 4
 - id: '1722445886802'

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -44,7 +44,8 @@ rest_command:
     payload: >-
       {"channel": {{ channel | tojson }}, "text": {{ text | tojson }},
        "username": {{ username | tojson }}, "icon_emoji": {{ icon_emoji | tojson }}
-       {% if blocks is defined and blocks %}, "blocks": {{ blocks }}{% endif %}}
+       {% if blocks is defined and blocks %}, "blocks": {{ blocks }}{% endif %}
+       {% if thread_ts is defined and thread_ts %}, "thread_ts": {{ thread_ts | tojson }}{% endif %}}
   slack_respond:
     url: "{{ response_url }}"
     method: POST


### PR DESCRIPTION
## Summary

- `notify.make_nashville` (UI-configured Slack integration) does not reliably pass `thread_ts` to the Slack API, so all lifecycle messages were posting to the main channel instead of as thread replies
- Switches Print Progress, Finished, Stopped, Error, Paused, and Resumed to call `rest_command.slack_post_3dprint` directly — the same bot-token API call already used by Print Starting
- Adds `thread_ts` support to the `rest_command.slack_post_3dprint` payload; when `thread_ts` is set it threads, when absent it falls back to a top-level post
- Inlines Block Kit JSON for Pause/Resume buttons in Progress, Paused, and Resumed (conditioned on `is_bambu`), matching the existing pattern in Print Starting
- Also fixes a latent bug where `from_json` was applied to the already-parsed response dict, silently leaving `thread_ts` empty after every Print Starting post

## Test plan

- [ ] Start a print on a Bambu printer — confirm Print Starting message appears in `#3dprint-info`
- [ ] Verify subsequent Progress, Paused, Resumed, Finished, Stopped, and Error messages appear as thread replies under the starting message
- [ ] Start a print on Pineapple — confirm same threading behavior, no Pause/Resume button blocks
- [ ] Confirm Pause/Resume Block Kit buttons still appear and function on Bambu printers
- [ ] Confirm fallback: if `thread_ts` is missing, message posts to main channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)