### PR TITLE
Add member-facing warehouse heat alerts

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -421,3 +421,34 @@
         username: Heat Watch
         icon: fire
   mode: single
+
+- id: warehouse_heat_midday_confirmation
+  alias: Warehouse Heat — Midday Confirmation
+  description: Confirm the morning prediction at 12:30pm if it's actually hot now
+  triggers:
+  - trigger: time
+    at: "12:30:00"
+  conditions:
+  - condition: state
+    entity_id: input_boolean.warehouse_heat_morning_fired
+    state: "on"
+  - condition: template
+    value_template: >
+      {{ states('input_datetime.warehouse_heat_morning_fired_at') == now().strftime('%Y-%m-%d') }}
+  - condition: numeric_state
+    entity_id: sensor.warehouse_max_heat_index
+    above: 88
+  actions:
+  - variables:
+      hottest: "{{ state_attr('sensor.warehouse_max_heat_index', 'hottest_area') }}"
+      hi: "{{ states('sensor.warehouse_max_heat_index') | float(0) | round(0) | int }}"
+  - action: notify.make_nashville
+    data:
+      target: "#facilities-feed"
+      message: |
+        :fire: *Yep, it's hot in here*
+        Right now the *{{ hottest }}* is the warmest at *{{ hi }}°F heat index*. Take breaks, hydrate, look out for each other.
+      data:
+        username: Heat Watch
+        icon: fire
+  mode: single

--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -452,3 +452,73 @@
         username: Heat Watch
         icon: fire
   mode: single
+
+- id: warehouse_heat_morning_headsup
+  alias: Warehouse Heat — Morning Heads-up
+  description: 7am forecast-based heat heads-up if today's peak HI will be 88+
+  triggers:
+  - trigger: time
+    at: "07:00:00"
+  actions:
+  - action: weather.get_forecasts
+    data:
+      type: hourly
+    target:
+      entity_id: weather.forecast_home
+    response_variable: weather_response
+  - variables:
+      forecast_today: >
+        {% set entries = weather_response['weather.forecast_home'].forecast | default([]) %}
+        {% set today = now().date() %}
+        {% set ns = namespace(items=[]) %}
+        {% for e in entries %}
+          {% set dt = e.datetime | as_datetime %}
+          {% if dt.date() == today and dt.hour >= 9 and dt.hour <= 20 %}
+            {% set t = e.temperature | float(0) %}
+            {% set rh = e.humidity | float(0) %}
+            {% if t < 80 %}
+              {% set hi = t %}
+            {% else %}
+              {% set hi = -42.379
+                + 2.04901523 * t
+                + 10.14333127 * rh
+                - 0.22475541 * t * rh
+                - 0.00683783 * t * t
+                - 0.05481717 * rh * rh
+                + 0.00122874 * t * t * rh
+                + 0.00085282 * t * rh * rh
+                - 0.00000199 * t * t * rh * rh %}
+            {% endif %}
+            {% set ns.items = ns.items + [{'hi': hi, 'hour': dt.hour, 'temp': t, 'rh': rh}] %}
+          {% endif %}
+        {% endfor %}
+        {{ ns.items }}
+      peak_hi: >
+        {{ (forecast_today | map(attribute='hi') | list | max | default(0)) | round(0) | int }}
+      peak_hour: >
+        {% set sorted = forecast_today | sort(attribute='hi', reverse=true) | list %}
+        {{ sorted[0].hour if sorted else 0 }}
+  - choose:
+    - conditions:
+      - condition: template
+        value_template: "{{ peak_hi >= 88 }}"
+      sequence:
+      - action: notify.make_nashville
+        data:
+          target: "#facilities-feed"
+          message: |
+            :sun_with_face: *Heads up — it's going to be hot today*
+            Forecast peak: *{{ peak_hi }}°F heat index* around {{ (peak_hour % 12) if (peak_hour % 12) != 0 else 12 }}{{ 'am' if peak_hour < 12 else 'pm' }}.
+            The warehouse usually runs warmer than outside. Dress light, bring water, plan breaks.
+          data:
+            username: Heat Watch
+            icon: sun_with_face
+      - action: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.warehouse_heat_morning_fired
+      - action: input_datetime.set_datetime
+        target:
+          entity_id: input_datetime.warehouse_heat_morning_fired_at
+        data:
+          date: "{{ now().strftime('%Y-%m-%d') }}"
+  mode: single

--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -351,3 +351,15 @@
         username: Facilities Pulse
         icon: warning
   mode: single
+
+- id: warehouse_heat_daily_reset
+  alias: Warehouse Heat — Daily Reset
+  description: Clear the morning-fired flag at midnight so it's fresh each day
+  triggers:
+  - trigger: time
+    at: "00:00:00"
+  actions:
+  - action: input_boolean.turn_off
+    target:
+      entity_id: input_boolean.warehouse_heat_morning_fired
+  mode: single

--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -384,7 +384,7 @@
       hi: "{{ states('sensor.warehouse_max_heat_index') | float(0) | round(0) | int }}"
   - action: notify.make_nashville
     data:
-      target: "#facilities-feed"
+      target: "#climate-feed"
       message: |
         :warning: *Warehouse is heating up*
         *{{ hottest }}* is at *{{ hi }}°F heat index* — it's officially uncomfortable in there. Hydrate and take breaks if you're working.
@@ -413,7 +413,7 @@
       hi: "{{ states('sensor.warehouse_max_heat_index') | float(0) | round(0) | int }}"
   - action: notify.make_nashville
     data:
-      target: "#facilities-feed"
+      target: "#climate-feed"
       message: |
         :fire: *Warehouse is HOT*
         *{{ hottest }}* is at *{{ hi }}°F heat index*. Take it seriously — drink water, take breaks, watch for signs of heat exhaustion in yourself and others.
@@ -444,7 +444,7 @@
       hi: "{{ states('sensor.warehouse_max_heat_index') | float(0) | round(0) | int }}"
   - action: notify.make_nashville
     data:
-      target: "#facilities-feed"
+      target: "#climate-feed"
       message: |
         :fire: *Yep, it's hot in here*
         Right now the *{{ hottest }}* is the warmest at *{{ hi }}°F heat index*. Take breaks, hydrate, look out for each other.
@@ -506,7 +506,7 @@
       sequence:
       - action: notify.make_nashville
         data:
-          target: "#facilities-feed"
+          target: "#climate-feed"
           message: |
             :sun_with_face: *Heads up — it's going to be hot today*
             Forecast peak: *{{ peak_hi }}°F heat index* around {{ (peak_hour % 12) if (peak_hour % 12) != 0 else 12 }}{{ 'am' if peak_hour < 12 else 'pm' }}.

--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -494,7 +494,8 @@
         {% endfor %}
         {{ ns.items }}
       peak_hi: >
-        {{ (forecast_today | map(attribute='hi') | list | max | default(0)) | round(0) | int }}
+        {% set hi_values = forecast_today | map(attribute='hi') | list %}
+        {{ (hi_values | max | round(0) | int) if hi_values else 0 }}
       peak_hour: >
         {% set sorted = forecast_today | sort(attribute='hi', reverse=true) | list %}
         {{ sorted[0].hour if sorted else 0 }}

--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -363,3 +363,61 @@
     target:
       entity_id: input_boolean.warehouse_heat_morning_fired
   mode: single
+
+- id: warehouse_heat_realtime_warm
+  alias: Warehouse Heat — Real-time (Warm)
+  description: Alert members when indoor heat index crosses 88°F (warm tier)
+  triggers:
+  - trigger: numeric_state
+    entity_id: sensor.warehouse_max_heat_index
+    above: 88
+    for:
+      minutes: 10
+  conditions:
+  - condition: template
+    value_template: >
+      {% set last = this.attributes.last_triggered %}
+      {{ last is none or (now() - last).total_seconds() > 14400 }}
+  actions:
+  - variables:
+      hottest: "{{ state_attr('sensor.warehouse_max_heat_index', 'hottest_area') }}"
+      hi: "{{ states('sensor.warehouse_max_heat_index') | float(0) | round(0) | int }}"
+  - action: notify.make_nashville
+    data:
+      target: "#facilities-feed"
+      message: |
+        :warning: *Warehouse is heating up*
+        *{{ hottest }}* is at *{{ hi }}°F heat index* — it's officially uncomfortable in there. Hydrate and take breaks if you're working.
+      data:
+        username: Heat Watch
+        icon: sun_with_face
+  mode: single
+
+- id: warehouse_heat_realtime_hot
+  alias: Warehouse Heat — Real-time (Hot)
+  description: Alert members when indoor heat index crosses 95°F (hot tier) — fires independently of warm-tier cooldown
+  triggers:
+  - trigger: numeric_state
+    entity_id: sensor.warehouse_max_heat_index
+    above: 95
+    for:
+      minutes: 10
+  conditions:
+  - condition: template
+    value_template: >
+      {% set last = this.attributes.last_triggered %}
+      {{ last is none or (now() - last).total_seconds() > 14400 }}
+  actions:
+  - variables:
+      hottest: "{{ state_attr('sensor.warehouse_max_heat_index', 'hottest_area') }}"
+      hi: "{{ states('sensor.warehouse_max_heat_index') | float(0) | round(0) | int }}"
+  - action: notify.make_nashville
+    data:
+      target: "#facilities-feed"
+      message: |
+        :fire: *Warehouse is HOT*
+        *{{ hottest }}* is at *{{ hi }}°F heat index*. Take it seriously — drink water, take breaks, watch for signs of heat exhaustion in yourself and others.
+      data:
+        username: Heat Watch
+        icon: fire
+  mode: single

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -463,6 +463,67 @@ template:
             {{ hi | round(1) }}
           {% endif %}
 
+      - name: "Warehouse Max Heat Index"
+        unique_id: warehouse_max_heat_index
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+        availability: >
+          {{ [
+               states('sensor.woodshop_heat_index'),
+               states('sensor.3d_print_heat_index'),
+               states('sensor.ceramics_heat_index'),
+               states('sensor.front_hallway_heat_index')
+             ] | reject('in', ['unknown', 'unavailable']) | list | length > 0 }}
+        state: >
+          {% set best = namespace(val=-1000, any=false) %}
+          {% for entity in [
+            'sensor.woodshop_heat_index',
+            'sensor.3d_print_heat_index',
+            'sensor.ceramics_heat_index',
+            'sensor.front_hallway_heat_index'
+          ] %}
+            {% set s = states(entity) %}
+            {% if s not in ['unknown', 'unavailable'] %}
+              {% set best.any = true %}
+              {% set v = s | float(0) %}
+              {% if v > best.val %}{% set best.val = v %}{% endif %}
+            {% endif %}
+          {% endfor %}
+          {% if best.any %}{{ best.val | round(1) }}{% else %}unavailable{% endif %}
+        attributes:
+          hottest_area: >
+            {% set best = namespace(name='unknown', val=-1000) %}
+            {% for name, entity in [
+              ('Woodshop',       'sensor.woodshop_heat_index'),
+              ('3D Print Room',  'sensor.3d_print_heat_index'),
+              ('Ceramics',       'sensor.ceramics_heat_index'),
+              ('Front Hallway',  'sensor.front_hallway_heat_index')
+            ] %}
+              {% set s = states(entity) %}
+              {% if s not in ['unknown', 'unavailable'] %}
+                {% set v = s | float(0) %}
+                {% if v > best.val %}
+                  {% set best.val = v %}
+                  {% set best.name = name %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+            {{ best.name }}
+          hottest_area_temperature: >
+            {% set name_to_temp = {
+              'Woodshop':       'sensor.woodshop_climate_sensor_temperature',
+              '3D Print Room':  'sensor.air_quality_temperature',
+              'Ceramics':       'sensor.ceramics_climate_sensor_temperature',
+              'Front Hallway':  'sensor.front_hallway_climate_sensor_temperature'
+            } %}
+            {% set hottest = state_attr('sensor.warehouse_max_heat_index', 'hottest_area') %}
+            {% if hottest in name_to_temp %}
+              {{ states(name_to_temp[hottest]) | float(0) | round(1) }}
+            {% else %}
+              0
+            {% endif %}
+
 sensor:
   # Weekly print counts — used by the Sunday metrics automation
   - platform: history_stats

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -136,6 +136,16 @@ input_boolean:
   deploy_restart_in_progress:
     name: Deploy Restart In Progress
     icon: mdi:restart
+  warehouse_heat_morning_fired:
+    name: Warehouse Heat Morning Fired
+    icon: mdi:weather-sunny-alert
+
+input_datetime:
+  warehouse_heat_morning_fired_at:
+    name: Warehouse Heat Morning Fired At
+    has_date: true
+    has_time: false
+    icon: mdi:calendar-clock
 
 recorder:
   purge_keep_days: 14

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -359,6 +359,32 @@ template:
         state: >
           {{states('sensor.dragonfruit_filename').replace(states('sensor.dragonfruit_display_name') + '-', '')}}
 
+      - name: "Woodshop Heat Index"
+        unique_id: woodshop_heat_index
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+        availability: >
+          {{ states('sensor.woodshop_climate_sensor_temperature') not in ['unknown', 'unavailable']
+             and states('sensor.woodshop_climate_sensor_humidity') not in ['unknown', 'unavailable'] }}
+        state: >
+          {% set t = states('sensor.woodshop_climate_sensor_temperature') | float(0) %}
+          {% set rh = states('sensor.woodshop_climate_sensor_humidity') | float(0) %}
+          {% if t < 80 %}
+            {{ t | round(1) }}
+          {% else %}
+            {% set hi = -42.379
+              + 2.04901523 * t
+              + 10.14333127 * rh
+              - 0.22475541 * t * rh
+              - 0.00683783 * t * t
+              - 0.05481717 * rh * rh
+              + 0.00122874 * t * t * rh
+              + 0.00085282 * t * rh * rh
+              - 0.00000199 * t * t * rh * rh %}
+            {{ hi | round(1) }}
+          {% endif %}
+
 sensor:
   # Weekly print counts — used by the Sunday metrics automation
   - platform: history_stats

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -385,6 +385,84 @@ template:
             {{ hi | round(1) }}
           {% endif %}
 
+      - name: "3D Print Heat Index"
+        unique_id: 3d_print_heat_index
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+        availability: >
+          {{ states('sensor.air_quality_temperature') not in ['unknown', 'unavailable']
+             and states('sensor.air_quality_humidity') not in ['unknown', 'unavailable'] }}
+        state: >
+          {% set t = states('sensor.air_quality_temperature') | float(0) %}
+          {% set rh = states('sensor.air_quality_humidity') | float(0) %}
+          {% if t < 80 %}
+            {{ t | round(1) }}
+          {% else %}
+            {% set hi = -42.379
+              + 2.04901523 * t
+              + 10.14333127 * rh
+              - 0.22475541 * t * rh
+              - 0.00683783 * t * t
+              - 0.05481717 * rh * rh
+              + 0.00122874 * t * t * rh
+              + 0.00085282 * t * rh * rh
+              - 0.00000199 * t * t * rh * rh %}
+            {{ hi | round(1) }}
+          {% endif %}
+
+      - name: "Ceramics Heat Index"
+        unique_id: ceramics_heat_index
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+        availability: >
+          {{ states('sensor.ceramics_climate_sensor_temperature') not in ['unknown', 'unavailable']
+             and states('sensor.ceramics_climate_sensor_humidity') not in ['unknown', 'unavailable'] }}
+        state: >
+          {% set t = states('sensor.ceramics_climate_sensor_temperature') | float(0) %}
+          {% set rh = states('sensor.ceramics_climate_sensor_humidity') | float(0) %}
+          {% if t < 80 %}
+            {{ t | round(1) }}
+          {% else %}
+            {% set hi = -42.379
+              + 2.04901523 * t
+              + 10.14333127 * rh
+              - 0.22475541 * t * rh
+              - 0.00683783 * t * t
+              - 0.05481717 * rh * rh
+              + 0.00122874 * t * t * rh
+              + 0.00085282 * t * rh * rh
+              - 0.00000199 * t * t * rh * rh %}
+            {{ hi | round(1) }}
+          {% endif %}
+
+      - name: "Front Hallway Heat Index"
+        unique_id: front_hallway_heat_index
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+        availability: >
+          {{ states('sensor.front_hallway_climate_sensor_temperature') not in ['unknown', 'unavailable']
+             and states('sensor.front_hallway_climate_sensor_humidity') not in ['unknown', 'unavailable'] }}
+        state: >
+          {% set t = states('sensor.front_hallway_climate_sensor_temperature') | float(0) %}
+          {% set rh = states('sensor.front_hallway_climate_sensor_humidity') | float(0) %}
+          {% if t < 80 %}
+            {{ t | round(1) }}
+          {% else %}
+            {% set hi = -42.379
+              + 2.04901523 * t
+              + 10.14333127 * rh
+              - 0.22475541 * t * rh
+              - 0.00683783 * t * t
+              - 0.05481717 * rh * rh
+              + 0.00122874 * t * t * rh
+              + 0.00085282 * t * rh * rh
+              - 0.00000199 * t * t * rh * rh %}
+            {{ hi | round(1) }}
+          {% endif %}
+
 sensor:
   # Weekly print counts — used by the Sunday metrics automation
   - platform: history_stats


### PR DESCRIPTION
## Summary

- Adds 5 heat-index template sensors (4 per-area + aggregate `warehouse_max_heat_index`) using the NWS Rothfusz formula
- Adds 5 new automations: 7am morning heads-up, 12:30pm midday confirmation, real-time warm tier (HI 88), real-time hot tier (HI 95), and a midnight reset
- Adds 2 helpers (`input_boolean.warehouse_heat_morning_fired`, `input_datetime.warehouse_heat_morning_fired_at`) for cross-automation state
- All member-facing messages post to **`#climate-feed`** as `Heat Watch` (new channel, member-facing equivalent of `#facilities-feed`)
- Existing `Facilities Pulse — Smart Alert` and other facilities automations are unchanged

> **Follow-up:** #103 (stacked) converts the 7am heads-up into a daily forecast post with chilly/comfortable/hot tiers so `#climate-feed` has year-round content. Merging this PR first is required.

### ⚠️ Before merging

Make sure the `#climate-feed` Slack channel exists and the `notify.make_nashville` bot is invited to it. Otherwise the alerts will silently fail.

### Design choices worth noting

- **Network closet excluded** from the member-facing aggregate (staff-only space)
- **Heat index, not raw temp** — Nashville humidity matters; the same 90°F day can feel very different
- **Real-time alerts split into two automations** (warm + hot) so each gets its own `last_triggered`, letting hot-tier escalation fire even while warm is in cooldown — no extra helpers needed
- **No recovery messages** — absence of further alerts is enough signal
- **10-minute debounce** on real-time triggers (longer than existing 5-min facilities debounce) since false positives are more annoying for member-facing comms

---

## Alert examples and logic

All four member-facing alerts post to `#climate-feed` as "Heat Watch".

### 1. Morning Heads-up

**Example message:**

> :sun_with_face: *Heads up — it's going to be hot today*
> Forecast peak: *96°F heat index* around 3pm.
> The warehouse usually runs warmer than outside. Dress light, bring water, plan breaks.

**Logic:**
- Fires at **07:00** every day
- Calls \`weather.get_forecasts\` (hourly) on \`weather.forecast_home\`
- For each forecast hour today between **09:00 and 20:00**, computes heat index from temp + humidity (Rothfusz formula; passthrough below 80°F)
- Finds the peak HI and the hour it occurs
- **If peak ≥ 88°F HI:** posts the message, sets \`input_boolean.warehouse_heat_morning_fired = on\`, sets \`input_datetime.warehouse_heat_morning_fired_at\` to today
- **Otherwise:** silent, no helper change

### 2. Midday Confirmation

**Example message:**

> :fire: *Yep, it's hot in here*
> Right now the *Woodshop* is the warmest at *93°F heat index*. Take breaks, hydrate, look out for each other.

**Logic:**
- Fires at **12:30** every day
- **All three conditions must be true:**
  1. \`input_boolean.warehouse_heat_morning_fired\` is \`on\` (this morning's heads-up went out)
  2. \`input_datetime.warehouse_heat_morning_fired_at\` equals today's date (defensive — flag isn't stuck on from a prior day)
  3. Current \`sensor.warehouse_max_heat_index\` ≥ 88°F
- If all true: posts message naming the hottest area
- If forecast was a miss and the warehouse never crossed 88: stays silent

### 3. Real-time Warm Tier

**Example message:**

> :warning: *Warehouse is heating up*
> *Woodshop* is at *89°F heat index* — it's officially uncomfortable in there. Hydrate and take breaks if you're working.

**Logic:**
- Triggers when \`sensor.warehouse_max_heat_index\` stays **above 88°F for 10 minutes** (debounce avoids transient spikes)
- **Cooldown:** suppressed if *this automation's* \`last_triggered\` was within the last 4 hours
- Independent from the Hot tier — having fired warm does NOT block hot from firing later

### 4. Real-time Hot Tier

**Example message:**

> :fire: *Warehouse is HOT*
> *Woodshop* is at *96°F heat index*. Take it seriously — drink water, take breaks, watch for signs of heat exhaustion in yourself and others.

**Logic:**
- Triggers when \`sensor.warehouse_max_heat_index\` stays **above 95°F for 10 minutes**
- **Cooldown:** suppressed if *this automation's* \`last_triggered\` was within the last 4 hours
- **Escalation:** because warm and hot are separate automations with separate \`last_triggered\` timestamps, hot fires the first time HI crosses 95 even if warm just fired 10 minutes earlier

### 5. Midnight Reset (no Slack message)

- Fires at **00:00:00** every day
- Action: turns \`input_boolean.warehouse_heat_morning_fired\` off
- Ensures the midday confirmation has a fresh signal each morning

### How the aggregate sensor ties it together

The \`hottest\` area name and \`hi\` value in every alert come from \`sensor.warehouse_max_heat_index\`. It loops over the four per-area heat-index sensors (Woodshop, 3D Print Room, Ceramics, Front Hallway), excludes any that are \`unknown\`/\`unavailable\`, and reports the max as state plus the area's friendly name as the \`hottest_area\` attribute.

---

## Test plan

- [ ] \`validate-yaml.yml\` passes
- [ ] \`#climate-feed\` Slack channel exists and bot is invited
- [ ] After merge & auto-deploy, all 5 new template sensors show in Developer Tools → States with numeric values
- [ ] \`sensor.warehouse_max_heat_index\` \`hottest_area\` attribute is populated
- [ ] Both helpers (\`input_boolean\`, \`input_datetime\`) appear in Developer Tools → States
- [ ] All 5 new automations appear in Settings → Automations & Scenes and are enabled
- [ ] On a forecasted hot day, observe the 7am heads-up message in \`#climate-feed\`
- [ ] If the day is actually hot by 12:30pm, observe the midday confirmation
- [ ] When indoor HI crosses 88 or 95 (real or simulated), observe the real-time alert from "Heat Watch"

🤖 Generated with [Claude Code](https://claude.com/claude-code)