### PR TITLE
Convert morning heads-up to daily climate forecast

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -454,8 +454,8 @@
   mode: single
 
 - id: warehouse_heat_morning_headsup
-  alias: Warehouse Heat — Morning Heads-up
-  description: 7am forecast-based heat heads-up if today's peak HI will be 88+
+  alias: Warehouse Climate — Daily Forecast
+  description: 7am daily forecast post; tiered messaging (chilly/comfortable/hot) and sets helpers on hot days
   triggers:
   - trigger: time
     at: "07:00:00"
@@ -522,4 +522,30 @@
           entity_id: input_datetime.warehouse_heat_morning_fired_at
         data:
           date: "{{ now().strftime('%Y-%m-%d') }}"
+    - conditions:
+      - condition: template
+        value_template: "{{ peak_hi >= 65 and peak_hi < 88 }}"
+      sequence:
+      - action: notify.make_nashville
+        data:
+          target: "#climate-feed"
+          message: |
+            :sun_with_face: *Today's forecast: peak around {{ peak_hi }}°F*
+            Comfortable conditions in the warehouse.
+          data:
+            username: Heat Watch
+            icon: sun_with_face
+    - conditions:
+      - condition: template
+        value_template: "{{ peak_hi > 0 and peak_hi < 65 }}"
+      sequence:
+      - action: notify.make_nashville
+        data:
+          target: "#climate-feed"
+          message: |
+            :cold_face: *Today's forecast: peak around {{ peak_hi }}°F*
+            Chilly day ahead — layer up if you're stopping by.
+          data:
+            username: Heat Watch
+            icon: cold_face
   mode: single


### PR DESCRIPTION
> **Stacked on top of #102.** Base will auto-rebase to `main` once #102 merges.

## Summary

Converts the 7am heat-alert automation into a **daily climate forecast** that always posts to `#climate-feed`, with tiered messaging instead of staying silent on non-hot days.

## Why

After #102 was drafted, the channel was renamed to \`#climate-feed\` to scale beyond just heat. With the original conditional behavior, the channel would only see traffic in summer — members would have no signal that the system was alive the other 9 months. A daily 7am heartbeat gives the channel year-round content and a useful "what kind of day is it" cue regardless of season.

## Behavior change

The 7am automation now picks a message tier based on the day's forecast peak heat index:

**Chilly day (HI < 65°F):**

> :cold_face: *Today's forecast: peak around 52°F*
> Chilly day ahead — layer up if you're stopping by.

**Comfortable day (HI 65–87°F):**

> :sun_with_face: *Today's forecast: peak around 75°F*
> Comfortable conditions in the warehouse.

**Hot day (HI ≥ 88°F)** *(unchanged from #102)*:

> :sun_with_face: *Heads up — it's going to be hot today*
> Forecast peak: *96°F heat index* around 3pm.
> The warehouse usually runs warmer than outside. Dress light, bring water, plan breaks.

**Hot tier only** still sets \`input_boolean.warehouse_heat_morning_fired\` and \`input_datetime.warehouse_heat_morning_fired_at\` so the midday confirmation can fire. The chilly and comfortable tiers post and exit.

**Empty-forecast fallback** (peak_hi = 0): no branch matches; channel stays silent. Same safe-failure mode as the original.

## Renames

- \`alias\` is now **"Warehouse Climate — Daily Forecast"** (was "Warehouse Heat — Morning Heads-up")
- \`description\` updated to reflect always-posts-with-tiers
- \`id\` unchanged (\`warehouse_heat_morning_headsup\`) to avoid touching anything else

## Test plan

- [ ] \`validate-yaml.yml\` passes
- [ ] After #102 + this merge, observe a 7am post in \`#climate-feed\` every day
- [ ] Verify message variant matches conditions (chilly / comfortable / hot)
- [ ] On a hot forecast day, confirm \`input_boolean.warehouse_heat_morning_fired\` is set to \`on\` and the midday confirmation still works
- [ ] On a comfortable or chilly day, confirm helpers stay \`off\` (no midday confirmation expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)