### PR TITLE
fix(printers): exclude pineapple fails from weekly summary

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -693,8 +693,10 @@
           {%- set ok = states('sensor.' ~ p.id ~ '_prints_completed_week') | int(0) %}
           {%- set fail = states('sensor.' ~ p.id ~ '_prints_failed_week') | int(0) %}
           {%- set ns.total_ok = ns.total_ok + ok %}
-          {%- set ns.total_fail = ns.total_fail + fail %}
-        {{ p.emoji }} {{ p.id | capitalize }}: {{ ok }} :white_check_mark:  {{ fail }} :x:
+          {%- if p.id != 'pineapple' %}
+            {%- set ns.total_fail = ns.total_fail + fail %}
+          {%- endif %}
+        {{ p.emoji }} {{ p.id | capitalize }}: {{ ok }} :white_check_mark:  {{ '—' if p.id == 'pineapple' else fail }} :x:
         {%- endfor %}
         ──────────────────────
         Total: {{ ns.total_ok }} :white_check_mark:  {{ ns.total_fail }} :x:


### PR DESCRIPTION
## Summary
- Pineapple's fail count renders as `—` in the Weekly Print Summary
- Pineapple's failures are no longer added into the Total fail count
- Completed counts (including pineapple's) are unchanged

## Test plan
- [ ] Wait for next Sunday 09:00 summary (or trigger manually) and confirm pineapple row shows `—ːx:` and Total fails excludes pineapple
- [ ] Confirm other printers' fail counts and totals still render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)