### PR TITLE
feat(sensors): add outdoor temperature helper from weather.home

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -237,6 +237,21 @@ template:
           {% elif co2 > 800  or voc > 150 or nox > 50  or pm25 > 12 %}Moderate
           {% else %}Good{% endif %}
 
+      - name: "Outdoor Temperature"
+        unique_id: outdoor_temperature
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+        availability: >
+          {{ state_attr('weather.home', 'temperature') is not none }}
+        state: >
+          {% set t = state_attr('weather.home', 'temperature') | float(0) %}
+          {% if state_attr('weather.home', 'temperature_unit') == '°C' %}
+            {{ ((t * 9 / 5) + 32) | round(1) }}
+          {% else %}
+            {{ t | round(1) }}
+          {% endif %}
+
       - name: "Kiwi Display Name"
         unique_id: kiwi_display_name
         availability: "{{ states('sensor.kiwi_gcode_filename') not in ['unknown', 'unavailable'] }}"


### PR DESCRIPTION
## Summary
- Adds `sensor.outdoor_temperature` template sensor that reads `weather.home`'s `temperature` attribute.
- Converts from C to F when the weather provider reports metric; otherwise passes through.
- Tagged `device_class: temperature` and `state_class: measurement` so it's recorder/statistics/dashboard-ready.

## Test plan
- [ ] After deploy, confirm `sensor.outdoor_temperature` appears in Developer Tools > States with a sensible F value.
- [ ] Verify it tracks `weather.home.temperature` and updates when the weather entity updates.
- [ ] Confirm the unit displays as F on the Facilities dashboard if added there.

Generated with [Claude Code](https://claude.com/claude-code)