### PR TITLE
Add Dragonfruit Prusa XL

### DIFF
--- a/automations/printers.yaml
+++ b/automations/printers.yaml
@@ -9,6 +9,7 @@
     - sensor.strawberry_current_layer
     - sensor.huckleberry_current_layer
     - sensor.pineapple_current_layer
+    - sensor.dragonfruit_current_layer
     for:
       seconds: 1
     to:
@@ -21,6 +22,7 @@
     - sensor.strawberry_current_layer
     - sensor.huckleberry_current_layer
     - sensor.pineapple_current_layer
+    - sensor.dragonfruit_current_layer
     for:
       seconds: 1
     to:
@@ -33,6 +35,7 @@
     - sensor.strawberry_print_progress
     - sensor.huckleberry_print_progress
     - sensor.pineapple_print_progress
+    - sensor.dragonfruit_print_progress
     for:
       seconds: 1
     to:
@@ -45,6 +48,7 @@
     - sensor.strawberry_print_progress
     - sensor.huckleberry_print_progress
     - sensor.pineapple_print_progress
+    - sensor.dragonfruit_print_progress
     for:
       seconds: 1
     to:
@@ -126,6 +130,7 @@
     - prepare
   - entity_id:
     - sensor.pineapple_print_status
+    - sensor.dragonfruit_print_status
     to:
     - printing
     from:
@@ -241,6 +246,15 @@
     trigger: state
     from:
     - printing
+  - entity_id:
+    - sensor.dragonfruit_print_status
+    to:
+    - finished
+    for:
+      seconds: 5
+    trigger: state
+    from:
+    - printing
   actions:
   - variables:
       printer: '{{ trigger.entity_id.split("_")[0].split(".")[1] }}'
@@ -291,6 +305,7 @@
     - running
   - entity_id:
     - sensor.pineapple_print_status
+    - sensor.dragonfruit_print_status
     to:
     - stopped
     for:
@@ -335,6 +350,7 @@
     - sensor.papaya_print_status
     - sensor.huckleberry_print_status
     - sensor.pineapple_print_status
+    - sensor.dragonfruit_print_status
     to:
     - error
     for:
@@ -434,6 +450,7 @@
     - running
   - entity_id:
     - sensor.pineapple_print_status
+    - sensor.dragonfruit_print_status
     to:
     - paused
     for:
@@ -503,6 +520,7 @@
     - pause
   - entity_id:
     - sensor.pineapple_print_status
+    - sensor.dragonfruit_print_status
     to:
     - printing
     for:
@@ -569,8 +587,8 @@
     value_template: "{{ now().hour >= 7 and now().hour < 22 }}"
   - condition: template
     value_template: |-
-      {% set printers = ['kiwi','mango','papaya','strawberry','huckleberry','pineapple'] %}
-      {% set not_printing = ['unavailable','idle','offline','finish','failed','completed','stopped','error','unknown','prepare'] %}
+      {% set printers = ['kiwi','mango','papaya','strawberry','huckleberry','pineapple','dragonfruit'] %}
+      {% set not_printing = ['unavailable','idle','offline','finish','failed','completed','finished','stopped','error','unknown','prepare'] %}
       {% set ns = namespace(active=false) %}
       {% for p in printers %}{% if states('sensor.' ~ p ~ '_print_status') not in not_printing %}{% set ns.active = true %}{% endif %}{% endfor %}
       {{ ns.active }}
@@ -588,8 +606,9 @@
           {"id":"strawberry","emoji":":strawberry:"},
           {"id":"huckleberry","emoji":":huckleberry:"},
           {"id":"pineapple","emoji":":pineapple:"},
+          {"id":"dragonfruit","emoji":":dragonfruit:"},
         ] %}
-        {%- set not_printing = ['unavailable','idle','offline','finish','failed','completed','stopped','error','unknown','prepare'] %}
+        {%- set not_printing = ['unavailable','idle','offline','finish','failed','completed','finished','stopped','error','unknown','prepare'] %}
         {%- set ns = namespace(active=0) %}
         {%- for p in printers %}
           {%- if states('sensor.' ~ p.id ~ '_print_status') not in not_printing %}
@@ -686,6 +705,7 @@
           {"id":"strawberry","emoji":":strawberry:"},
           {"id":"huckleberry","emoji":":huckleberry:"},
           {"id":"pineapple","emoji":":pineapple:"},
+          {"id":"dragonfruit","emoji":":dragonfruit:"},
         ] %}
         {%- set ns = namespace(total_ok=0, total_fail=0) %}
         :bar_chart: Weekly Print Summary (last 7 days)
@@ -714,7 +734,7 @@
   conditions:
   - condition: template
     value_template: >
-      {% set printers = ['kiwi','mango','papaya','strawberry','huckleberry','pineapple'] %}
+      {% set printers = ['kiwi','mango','papaya','strawberry','huckleberry','pineapple','dragonfruit'] %}
       {% set ns = namespace(offline=0) %}
       {% for p in printers %}
         {% if states('sensor.' ~ p ~ '_print_status') in ['unavailable','unknown','offline'] %}
@@ -727,7 +747,7 @@
     data:
       target: "#facilities-feed"
       message: >
-        {% set printers = ['kiwi','mango','papaya','strawberry','huckleberry','pineapple'] %}
+        {% set printers = ['kiwi','mango','papaya','strawberry','huckleberry','pineapple','dragonfruit'] %}
         {% set ns = namespace(offline=0, names=[]) %}
         {% for p in printers %}
           {% if states('sensor.' ~ p ~ '_print_status') in ['unavailable','unknown','offline'] %}

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -101,6 +101,9 @@ rest_command:
     payload: '{{ payload }}'
 
 input_text:
+  dragonfruit_slack_thread_ts:
+    name: Dragonfruit Slack Thread TS
+    max: 30
   pineapple_last_job:
     name: Pineapple Last Job
     max: 255
@@ -372,7 +375,6 @@ template:
         availability: "{{ states('sensor.pineapple_last_display_name') not in ['unknown', 'unavailable'] }}"
         state: >
           {{states('input_text.pineapple_last_job').replace(states('sensor.pineapple_last_display_name') + '-', '')}}
-
       - name: "Dragonfruit Display Name"
         unique_id: dragonfruit_display_name
         availability: "{{ states('sensor.dragonfruit_filename') not in ['unknown', 'unavailable'] }}"
@@ -383,6 +385,16 @@ template:
         availability: "{{ states('sensor.dragonfruit_display_name') not in ['unknown', 'unavailable'] }}"
         state: >
           {{states('sensor.dragonfruit_filename').replace(states('sensor.dragonfruit_display_name') + '-', '')}}
+      - name: "Dragonfruit Last Display Name"
+        unique_id: dragonfruit_last_display_name
+        availability: "{{ states('sensor.dragonfruit_filename') not in ['unknown', 'unavailable'] }}"
+        state: >
+          {{states('sensor.dragonfruit_filename').split('-')[0]}}
+      - name: "Dragonfruit Last Object"
+        unique_id: dragonfruit_last_object
+        availability: "{{ states('sensor.dragonfruit_last_display_name') not in ['unknown', 'unavailable'] }}"
+        state: >
+          {{states('sensor.dragonfruit_filename').replace(states('sensor.dragonfruit_last_display_name') + '-', '')}}
 
       - name: "Woodshop Heat Index"
         unique_id: woodshop_heat_index
@@ -641,6 +653,20 @@ sensor:
   - platform: history_stats
     name: Pineapple Prints Failed Week
     entity_id: sensor.pineapple_print_status
+    state: "stopped"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Dragonfruit Prints Completed Week
+    entity_id: sensor.dragonfruit_print_status
+    state: "finished"
+    type: count
+    start: "{{ now() - timedelta(days=7) }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Dragonfruit Prints Failed Week
+    entity_id: sensor.dragonfruit_print_status
     state: "stopped"
     type: count
     start: "{{ now() - timedelta(days=7) }}"


### PR DESCRIPTION
Adds Dragonfruit, a Prusa printer, following the "Adding a new printer" steps. Wired into all printer lists and lifecycle automations in printers.yaml, plus the thread helper, four template name sensors, and weekly history_stats in configuration.yaml.