### PR TITLE
Deploy: full restart when a new automation is added

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,20 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Check if configuration.yaml changed (requires full restart)
+      - name: Check if full restart required
         id: restart_check
+        # Restart is required when:
+        #   1. configuration.yaml changed (core config / template sensors / includes).
+        #   2. A new top-level automation entry was added under automations/.
+        #      automation.reload reliably refreshes existing automations but can
+        #      silently skip registration for brand-new entries.
         run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qE '^(configuration\.yaml)'; then
+          if git diff --name-only HEAD~1 HEAD | grep -qE '^configuration\.yaml$'; then
             echo "required=true" >> $GITHUB_OUTPUT
+            echo "reason=configuration.yaml changed" >> $GITHUB_OUTPUT
+          elif git diff HEAD~1 HEAD -- automations/ | grep -qE '^\+- id: '; then
+            echo "required=true" >> $GITHUB_OUTPUT
+            echo "reason=new automation entry added" >> $GITHUB_OUTPUT
           else
             echo "required=false" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary
- `automation.reload` reliably refreshes existing automation entries but can silently skip registration for brand-new ones. PR #110 hit this: the new `warehouse_heat_hourly_status` block landed on `main` and validated, but never registered in HA after the hot-reload deploy.
- Route diffs that add a new top-level `- id:` line under `automations/` through the restart path instead of the hot-reload path.
- Existing-entry edits (threshold tweaks, message copy, renames) still take the faster reload path.

## Detection logic
```bash
if git diff --name-only HEAD~1 HEAD | grep -qE '^configuration\.yaml$'; then
  # core config changed — restart
elif git diff HEAD~1 HEAD -- automations/ | grep -qE '^\+- id: '; then
  # new automation entry — restart
else
  # reload
fi
```

Verified locally against recent merges:
- PR #110 (added one automation): detected, routes to restart
- PR #108 (EV3 monitor, no new automations): no match, stays on reload

## Test plan
- [ ] CI `validate-yaml.yml` passes
- [ ] After merge, `deploy.yml` posts a `:white_check_mark: full restart complete` message to `#deployment-feed` (since this PR adds zero new automations, it should *not* restart — but the deploy.yml file itself changed, so the workflow will run; expect the reload path)
- [ ] Next PR that adds a new automation should trigger the restart path

🤖 Generated with [Claude Code](https://claude.com/claude-code)