### PR TITLE
Switch from core_ssh to Advanced SSH addon for backup and git pull

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,12 +33,16 @@ jobs:
             echo "required=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Git pull config on HA host
+      - name: Git pull config on HA host (via SSH addon)
+        # shell_command runs in the HA Core container, which doesn't ship
+        # git. Run the pull inside the Advanced SSH addon instead, which
+        # has git available and read access to /config.
         run: |
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
             -H "Content-Type: application/json" \
-            "${{ secrets.HA_URL }}/api/services/shell_command/git_pull"
+            -d '{"addon": "a0d7b954_ssh", "input": "git -C /config pull --rebase origin main"}' \
+            "${{ secrets.HA_URL }}/api/services/hassio/addon_stdin"
 
       - name: Wait 5s for git pull to finish
         run: sleep 5
@@ -188,7 +192,7 @@ jobs:
           curl -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"addon": "core_ssh", "input": "bash /config/git_backup.sh"}' \
+            -d '{"addon": "a0d7b954_ssh", "input": "bash /config/git_backup.sh"}' \
             "${{ secrets.HA_URL }}/api/services/hassio/addon_stdin"
 
       # --- Failure notification ---

--- a/automations/backup.yaml
+++ b/automations/backup.yaml
@@ -10,7 +10,7 @@
   - sequence:
     - action: hassio.addon_stdin
       data:
-        addon: core_ssh
+        addon: a0d7b954_ssh
         input: "bash /config/git_backup.sh"
   mode: single
 

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -31,7 +31,6 @@ lovelace:
       require_admin: false
 
 shell_command:
-  git_pull: "git -C /config pull --rebase origin main"
   write_entity_list: "bash /config/write_entity_list.sh"
 
 rest_command:


### PR DESCRIPTION
## Summary

Two services broke recently:

1. **`hassio.addon_stdin` to `core_ssh`** is now rejected with `App core_ssh does not support writing to stdin`, breaking the nightly backup automation and the deploy workflow's post-deploy backup-trigger step.
2. **`shell_command/git_pull`** runs in the HA Core container, which no longer ships `git`. So HA never actually pulls the latest config after a merge; \`check_config\` validates the stale on-disk copy and new automations silently never register. This is why PR #110's new `warehouse_heat_hourly_status` automation doesn't exist as an entity even after a full restart.

Both can be solved by routing through the **Advanced SSH & Web Terminal** community addon (slug `a0d7b954_ssh`), which still supports stdin and ships with `git`, `jq`, and bash by default.

## Changes

| File | Change |
|---|---|
| `automations/backup.yaml` | `addon: core_ssh` → `addon: a0d7b954_ssh` |
| `.github/workflows/deploy.yml` | "Git pull config on HA host" step switched from `shell_command/git_pull` to `hassio.addon_stdin` via the new addon |
| `.github/workflows/deploy.yml` | "Trigger nightly backup" step's addon name updated |
| `configuration.yaml` | Drop the now-unused `shell_command/git_pull` (the `write_entity_list` shell_command stays since `git_backup.sh` calls it directly via bash) |

## Prerequisite

The **Advanced SSH & Web Terminal** addon must be installed and running on the HA host before this merges. Verify the slug locally with `ha addons list | grep ssh` — typical slug is `a0d7b954_ssh` but it can differ depending on which add-on repo it was installed from. If yours differs, update the three references before merging.

## Catch-22: how to deploy this fix when the existing deploy is broken

Because `shell_command/git_pull` is the very thing this PR is fixing, the PR's own deploy run cannot pull itself. One manual pull is needed once to bridge over:

1. Open the SSH addon's web terminal (or any container with `/config` mounted).
2. Run:
   ```bash
   cd /config && git pull --rebase origin main
   ```
3. In HA: Settings → System → Restart (since `configuration.yaml` changed, a restart is required anyway).

After that, every future deploy self-updates via the fixed pull step.

## Test plan
- [ ] CI `validate-yaml.yml` passes
- [ ] Advanced SSH addon installed and running, slug verified
- [ ] Manual pull + restart on HA host as described above
- [ ] After restart, the deploy workflow's next run posts `:white_check_mark: full restart complete` (since this PR changed `configuration.yaml`)
- [ ] `automation.warehouse_heat_hourly_status` now appears in Developer Tools → States (the catch-up effect of the manual pull bringing in PR #110's new automation)
- [ ] Manually trigger `Backup Config to GitHub` from HA UI — should succeed, ha-backup branch advances, no `stdin` error in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)