### PR TITLE
Pull /config via custom git_sync integration (no addon required)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,16 +42,15 @@ jobs:
             echo "required=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Git pull config on HA host (via SSH addon)
-        # shell_command runs in the HA Core container, which doesn't ship
-        # git. Run the pull inside the Advanced SSH addon instead, which
-        # has git available and read access to /config.
+      - name: Git pull config on HA host (via git_sync integration)
+        # Calls our custom_components/git_sync integration. It runs inside
+        # HA Core using dulwich (pure-Python git), so no SSH addon and no
+        # git binary on the host are required.
         run: |
           curl -f -s -X POST \
             -H "Authorization: Bearer ${{ secrets.HA_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"addon": "a0d7b954_ssh", "input": "git -C /config pull --rebase origin main"}' \
-            "${{ secrets.HA_URL }}/api/services/hassio/addon_stdin"
+            "${{ secrets.HA_URL }}/api/services/git_sync/pull"
 
       - name: Wait 5s for git pull to finish
         run: sleep 5

--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,8 @@ esphome/secrets.yaml
 # === BLUEPRINTS (built-in HA blueprints, not custom) ===
 blueprints/*/homeassistant/
 
-custom_components/
+# Ignore external/HACS-managed integrations under custom_components/
+# but keep our own tracked. Use the /* pattern (not custom_components/)
+# so git still descends into the directory and honors the !exception.
+custom_components/*
+!custom_components/git_sync/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ A fine-grained GitHub PAT is stored at `/config/.github_token` with `Contents: w
 - `secrets.yaml` — gitignored; must exist on the HA host
 - `esphome/secrets.yaml` — gitignored; must exist on the HA host
 - `.storage/` — gitignored; HA runtime state
-- `custom_components/` — gitignored
+- `custom_components/` — gitignored, with one exception: `custom_components/git_sync/` is our own integration and IS tracked (see `Custom integrations we own` below). Everything else under `custom_components/` (HACS, browser_mod, etc.) is managed externally and stays untracked.
 
 ---
 
@@ -122,9 +122,23 @@ Both scripts run inside the **SSH addon** container, not the HA core container.
 
 ---
 
+## Custom integrations we own
+
+`custom_components/git_sync/` — small HA integration that exposes the `git_sync.pull` service. The deploy workflow calls it after each merge to `git fetch origin && reset --hard origin/main` inside `/config`. Uses `dulwich` (pure-Python git) so it works regardless of whether the HA Core container ships the `git` binary. Enabled in `configuration.yaml` with `git_sync:`.
+
+Everything else under `custom_components/` (HACS, browser_mod, ha_creality_ws, bambu_lab) is managed externally and stays gitignored.
+
+---
+
 ## Deploy workflow details
 
-`deploy.yml` detects whether a full restart or a hot reload is needed by checking if `configuration.yaml` changed in the commit. Restart path notifies Slack first, then restarts. Reload path reloads automations, scripts, scenes, themes, and core config, then notifies. Failure always notifies with a link to the commit and the Actions run.
+`deploy.yml` detects whether a full restart or a hot reload is needed by:
+1. `configuration.yaml` changed in the commit (core config changes need restart), OR
+2. A new top-level `- id:` line was added under `automations/` (`automation.reload` reliably refreshes existing automations but can silently skip registration for brand-new ones).
+
+Restart path notifies Slack first, then restarts. Reload path reloads automations, scripts, scenes, themes, and core config, then notifies. Failure always notifies with a link to the commit and the Actions run.
+
+Config pull onto the HA host goes through the `git_sync.pull` service (see above), not `shell_command` or an addon stdin call.
 
 ---
 

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -33,6 +33,11 @@ lovelace:
 shell_command:
   write_entity_list: "bash /config/write_entity_list.sh"
 
+# Custom integration in custom_components/git_sync/. Exposes
+# git_sync.pull, called by the deploy workflow to sync /config to
+# origin/main without needing the SSH addon or git binary.
+git_sync:
+
 rest_command:
   slack_post_3dprint:
     url: https://slack.com/api/chat.postMessage

--- a/custom_components/git_sync/__init__.py
+++ b/custom_components/git_sync/__init__.py
@@ -1,0 +1,67 @@
+"""Git Sync — pull main from GitHub into /config on the HA host.
+
+Exposes one service, ``git_sync.pull``, that fetches origin and
+hard-resets /config to origin/main. The GitHub Actions deploy workflow
+calls this service after each merge so new commits land on the HA host
+without depending on the SSH addon's stdin support (removed for
+core_ssh) or the git binary (no longer shipped in the HA Core
+container image).
+
+Implemented with dulwich (pure-Python git) so it has no system-binary
+or addon dependency.
+"""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "git_sync"
+CONFIG_DIR = "/config"
+REMOTE = "origin"
+BRANCH = "main"
+
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Register the git_sync.pull service."""
+
+    async def handle_pull(_: ServiceCall) -> None:
+        await hass.async_add_executor_job(_fast_forward_to_origin_main)
+
+    hass.services.async_register(DOMAIN, "pull", handle_pull)
+    return True
+
+
+def _fast_forward_to_origin_main() -> None:
+    """Fetch origin and hard-reset /config to origin/main.
+
+    Runs in the executor (dulwich is sync). Hard reset is intentional:
+    deploy semantics treat main as source of truth, so any uncommitted
+    edits on the HA host are discarded.
+    """
+    from dulwich import porcelain
+    from dulwich.repo import Repo
+
+    repo = Repo(CONFIG_DIR)
+    porcelain.fetch(repo, REMOTE)
+
+    remote_ref = f"refs/remotes/{REMOTE}/{BRANCH}".encode()
+    local_ref = f"refs/heads/{BRANCH}".encode()
+    target_sha = repo.refs[remote_ref]
+
+    repo.refs[local_ref] = target_sha
+    repo.refs.set_symbolic_ref(b"HEAD", local_ref)
+    porcelain.reset(repo, "hard", target_sha)
+
+    _LOGGER.info(
+        "git_sync.pull synced /config to %s/%s @ %s",
+        REMOTE,
+        BRANCH,
+        target_sha.decode()[:7],
+    )

--- a/custom_components/git_sync/manifest.json
+++ b/custom_components/git_sync/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "git_sync",
+  "name": "Git Sync",
+  "version": "0.1.0",
+  "documentation": "https://github.com/MakeNashville/home-assistant-config",
+  "codeowners": ["@kevinahuber"],
+  "iot_class": "local_polling",
+  "requirements": ["dulwich==0.22.7"]
+}

--- a/custom_components/git_sync/services.yaml
+++ b/custom_components/git_sync/services.yaml
@@ -1,0 +1,7 @@
+pull:
+  name: Pull main
+  description: >-
+    Fetch origin and fast-forward /config to origin/main. The hard reset
+    discards any uncommitted local changes; main is treated as source of
+    truth. Called by the GitHub Actions deploy workflow after each merge.
+  fields: {}


### PR DESCRIPTION
## Why

Two of the previous "how do we get config from GitHub onto the HA host" paths are now broken:
- `shell_command/git_pull` runs inside the HA Core container, which no longer ships the `git` binary. Silent failure.
- `hassio.addon_stdin` no longer works against `core_ssh` (the addon dropped stdin support). PR #112 switched to `a0d7b954_ssh` (Advanced SSH & Web Terminal), but that requires installing a separate community addon.

Rather than depend on a particular addon being installed, drop in a tiny custom integration that does the pull itself, in Python, inside HA Core.

## Approach

New custom integration at `custom_components/git_sync/`. ~50 lines of Python plus a manifest and services descriptor.

- One service: `git_sync.pull`. Fetches `origin` and hard-resets `/config` to `origin/main`. Hard reset because the deploy treats `main` as source of truth — any uncommitted local edits get discarded.
- Implemented with [`dulwich`](https://www.dulwich.io/), a pure-Python git library. No addon, no system git binary, no PATH games.
- Wired into HA via `git_sync:` in `configuration.yaml`.
- Called by the deploy workflow's pull step.

## Files

| File | Change |
|---|---|
| `custom_components/git_sync/manifest.json` | new — declares integration, pins `dulwich==0.22.7` |
| `custom_components/git_sync/__init__.py` | new — registers `git_sync.pull` service |
| `custom_components/git_sync/services.yaml` | new — service descriptor for the HA UI |
| `.gitignore` | switch `custom_components/` to `custom_components/*` + re-include `git_sync/` so it stays tracked while external/HACS components stay ignored |
| `configuration.yaml` | add `git_sync:` to enable the integration |
| `.github/workflows/deploy.yml` | pull step calls `git_sync.pull` instead of `hassio.addon_stdin` |
| `CLAUDE.md` | document the integration and the gitignore exception; refresh the deploy-workflow section |

## Out of scope

- **Backup automation.** Still calls `hassio.addon_stdin` against `a0d7b954_ssh` and will keep failing until either the Advanced SSH addon is installed *or* a follow-up adds a `git_sync.push_backup` service. Not worse than the current state.
- `git_backup.sh` and `write_entity_list.sh` — unchanged; would only be touched by the backup follow-up.

## Catch-22, again

This PR's deploy will not be able to pull itself, because the on-host pull mechanism it replaces is currently broken. One manual bridge is needed:

1. Get the integration files onto the host. From the File Editor addon (or any container with `/config` mounted), pull main manually — e.g., copy the three files from this branch into `/config/custom_components/git_sync/`, then edit `/config/configuration.yaml` to add `git_sync:`.
2. **Settings → System → Restart.** First load installs `dulwich` via HA's requirements system; takes ~30s extra.
3. After restart, the integration is live. The next deploy works end-to-end.

Alternatively, since the goal is just "get current `main` on the host," step 1 could be `cd /config && git pull --rebase origin main` from anywhere with shell access — same result.

## Supersedes

- #112 (the Advanced SSH addon swap). Closing it after this lands. Backup is still broken in both cases; this PR avoids the addon prerequisite.

## Test plan
- [ ] CI `validate-yaml.yml` passes
- [ ] Files copied to HA host + restart
- [ ] HA log shows `git_sync` integration loaded (Settings → System → Logs, filter `git_sync`)
- [ ] Developer Tools → Actions → `git_sync.pull` → Perform action. Confirm `/config` advances to the latest `main` commit (check `git -C /config log -1` from any shell, or just check that recent commits' content is in the files)
- [ ] Next deploy run completes without the curl `exit code 22` failure on the pull step
- [ ] `automation.warehouse_heat_hourly_status` finally appears as an entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)