### PR TITLE
Raise per-row warning icon threshold to 85°F HI

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -602,7 +602,7 @@
         {% set t = t_raw | float(0) -%}
         {% set h = h_raw | float(0) -%}
         {% set hi = hi_raw | float(0) -%}
-        {% set icon = ':rotating_light:' if hi >= 103 else ':hot_face:' if hi >= 90 else ':warning:' if hi >= 80 else ':white_check_mark:' -%}
+        {% set icon = ':rotating_light:' if hi >= 103 else ':hot_face:' if hi >= 90 else ':warning:' if hi >= 85 else ':white_check_mark:' -%}
         {{ icon }} {{ "%-17s"|format(a.name) }} {{ "%.1f°F"|format(t) }}  {{ h | round(0) | int }}%  → {{ hi | round(0) | int }}°F HI
         {% endif -%}
         {% endfor -%}
@@ -621,7 +621,7 @@
           + 0.00085282 * ot * orh * orh
           - 0.00000199 * ot * ot * orh * orh -%}
         {% endif -%}
-        {% set out_icon = ':rotating_light:' if out_hi >= 103 else ':hot_face:' if out_hi >= 90 else ':warning:' if out_hi >= 80 else ':white_check_mark:' -%}
+        {% set out_icon = ':rotating_light:' if out_hi >= 103 else ':hot_face:' if out_hi >= 90 else ':warning:' if out_hi >= 85 else ':white_check_mark:' -%}
         {{ out_icon }} {{ "%-17s"|format('Outside') }} {{ "%.1f°F"|format(ot) }}  {{ orh | round(0) | int }}%  → {{ out_hi | round(0) | int }}°F HI
         {{ care_line -}}
   mode: single


### PR DESCRIPTION
## Change
The hourly-status per-row `:warning:` icon now appears at HI >= 85 instead of >= 80. Rows in the 80–84°F HI band show `:white_check_mark:` along with the genuinely-fine areas.

## Why
80°F HI is borderline-comfortable, not cautionary. Showing a warning icon there overstates the situation and conflicts with the rest of the post (which the title icon already treats as informational below 90°F).

## What stays the same
- Hourly trigger: still fires when `sensor.warehouse_max_heat_index > 80`. The post still runs across the 80–84 band; it just reads as informational rather than cautionary.
- `:hot_face:` row icon at HI >= 90.
- `:rotating_light:` row icon at HI >= 103.
- Care-line copy thresholds (none < 90, "Stress conditions" at 90, "Dangerous heat" at 103).
- Daily forecast / midday confirmation tiers (separate concept, anchored at 80 for the "going to be hot" warning).

## Test plan
- [ ] CI passes
- [ ] After deploy, manually trigger `Warehouse Heat — Hourly Status` from the HA UI on a moderately-warm afternoon and confirm the per-row icons match expectations (green check for areas under 85°F HI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)