### PR TITLE
git_sync: narrow fetch to refs/heads/main only

### DIFF
--- a/custom_components/git_sync/__init__.py
+++ b/custom_components/git_sync/__init__.py
@@ -1,14 +1,20 @@
 """Git Sync — pull main from GitHub into /config on the HA host.
 
-Exposes one service, ``git_sync.pull``, that fetches origin and
-hard-resets /config to origin/main. The GitHub Actions deploy workflow
-calls this service after each merge so new commits land on the HA host
-without depending on the SSH addon's stdin support (removed for
-core_ssh) or the git binary (no longer shipped in the HA Core
-container image).
+Exposes one service, ``git_sync.pull``, that fetches the origin/main
+commit and hard-resets /config to it. The GitHub Actions deploy
+workflow calls this service after each merge so new commits land on
+the HA host without depending on the SSH addon's stdin support
+(removed for core_ssh) or the git binary (no longer shipped in the
+HA Core container image).
 
-Implemented with dulwich (pure-Python git) so it has no system-binary
-or addon dependency.
+Implemented with dulwich (pure-Python git). Uses the low-level
+``client.fetch`` + targeted ref writes rather than ``porcelain.fetch``
+so it does NOT try to mirror every remote ref locally. The backup
+automation pushes branches like ``ha-backup/<date>`` that can leave
+``refs/remotes/origin/`` in a state where a regular file and a
+directory want to live at the same path; ``porcelain.fetch`` cannot
+write through that, but we don't need to — the deploy only cares
+about main.
 """
 from __future__ import annotations
 
@@ -39,22 +45,37 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 
 def _fast_forward_to_origin_main() -> None:
-    """Fetch origin and hard-reset /config to origin/main.
+    """Fetch the latest main from origin and hard-reset /config to it.
 
-    Runs in the executor (dulwich is sync). Hard reset is intentional:
-    deploy semantics treat main as source of truth, so any uncommitted
-    edits on the HA host are discarded.
+    Uses dulwich's low-level ``client.fetch`` with a ``determine_wants``
+    callback that asks for exactly one ref. ``refs/remotes/origin/main``
+    is deliberately NOT updated: see the module docstring for why.
+    Only ``refs/heads/main`` and ``HEAD`` get touched.
     """
     from dulwich import porcelain
+    from dulwich.client import get_transport_and_path
     from dulwich.repo import Repo
 
     repo = Repo(CONFIG_DIR)
-    porcelain.fetch(repo, REMOTE)
+    config = repo.get_config()
+    url = config.get((b"remote", REMOTE.encode()), b"url")
+    if isinstance(url, bytes):
+        url = url.decode()
 
-    remote_ref = f"refs/remotes/{REMOTE}/{BRANCH}".encode()
+    client, path = get_transport_and_path(url)
+    wanted_ref = f"refs/heads/{BRANCH}".encode()
+
+    def determine_wants(remote_refs, **_kwargs):
+        if wanted_ref not in remote_refs:
+            raise RuntimeError(
+                f"Remote {REMOTE!r} does not advertise {wanted_ref.decode()!r}"
+            )
+        return [remote_refs[wanted_ref]]
+
+    fetch_result = client.fetch(path, repo, determine_wants=determine_wants)
+    target_sha = fetch_result.refs[wanted_ref]
+
     local_ref = f"refs/heads/{BRANCH}".encode()
-    target_sha = repo.refs[remote_ref]
-
     repo.refs[local_ref] = target_sha
     repo.refs.set_symbolic_ref(b"HEAD", local_ref)
     porcelain.reset(repo, "hard", target_sha)


### PR DESCRIPTION
## Why

The current `git_sync.pull` calls `porcelain.fetch(repo, REMOTE)`, which tries to mirror **every** remote ref into `refs/remotes/origin/`. The backup automation has historically pushed branches like `ha-backup/<date>`, so the remote advertises a fan of refs under `refs/heads/ha-backup/*`. Locally, `refs/remotes/origin/ha-backup` already exists as a single ref file (from a clone that predated the date-suffix branches), so dulwich can't create a directory in its place and the fetch dies mid-import:

```
NotADirectoryError: [Errno 20] Not a directory: b'/config/.git/refs/remotes/origin/ha-backup/2026-02-28-1341.lock'
```

Observed on the host while trying to manually invoke `git_sync.pull` after the v1 integration was installed.

## Fix

Drop down to dulwich's low-level `client.fetch` with a `determine_wants` callback that asks for exactly one ref: `refs/heads/main`. Only `refs/heads/main` and `HEAD` get touched locally. The corrupt `refs/remotes/origin/ha-backup` ref file stays as-is — the deploy doesn't need it and we don't have to repair it to make the pull work.

This is the same fix commit (`49281e0`) that landed on `feature/git-sync-integration` after PR #113 was merged, cherry-picked onto a fresh branch off `main` so it's mergeable.

## Test plan
- [ ] Replace `/config/custom_components/git_sync/__init__.py` on the HA host with this branch's version (one-line `scp` or `curl | tee`), restart HA, call `git_sync.pull` from Developer Tools → Actions
- [ ] HA log shows a single info line: `git_sync.pull synced /config to origin/main @ <7-char SHA>`
- [ ] After merge, the next deploy completes without the `NotADirectoryError` on the pull step

🤖 Generated with [Claude Code](https://claude.com/claude-code)