### PR TITLE
refactor(climate-feed): drop alerts and heat-index math, report raw temperature

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -352,110 +352,9 @@
         icon: warning
   mode: single
 
-- id: warehouse_heat_daily_reset
-  alias: Warehouse Heat — Daily Reset
-  description: Clear the morning-fired flag at midnight so it's fresh each day
-  triggers:
-  - trigger: time
-    at: "00:00:00"
-  actions:
-  - action: input_boolean.turn_off
-    target:
-      entity_id: input_boolean.warehouse_heat_morning_fired
-  mode: single
-
-- id: warehouse_heat_realtime_warm
-  alias: Warehouse Heat — Real-time (Warm)
-  description: Alert members when indoor heat index crosses 88°F (warm tier)
-  triggers:
-  - trigger: numeric_state
-    entity_id: sensor.warehouse_max_heat_index
-    above: 88
-    for:
-      minutes: 10
-  conditions:
-  - condition: template
-    value_template: >
-      {% set last = this.attributes.last_triggered %}
-      {{ last is none or (now() - last).total_seconds() > 14400 }}
-  actions:
-  - variables:
-      hottest: "{{ state_attr('sensor.warehouse_max_heat_index', 'hottest_area') }}"
-      hi: "{{ states('sensor.warehouse_max_heat_index') | float(0) | round(0) | int }}"
-  - action: notify.make_nashville
-    data:
-      target: "#climate-feed"
-      message: |
-        :warning: *Warehouse is heating up*
-        *{{ hottest }}* is at *{{ hi }}°F heat index* — it's officially uncomfortable in there. Hydrate and take breaks if you're working.
-      data:
-        username: Climate Watch
-        icon: sun_with_face
-  mode: single
-
-- id: warehouse_heat_realtime_hot
-  alias: Warehouse Heat — Real-time (Hot)
-  description: Alert members when indoor heat index crosses 95°F (hot tier) — fires independently of warm-tier cooldown
-  triggers:
-  - trigger: numeric_state
-    entity_id: sensor.warehouse_max_heat_index
-    above: 95
-    for:
-      minutes: 10
-  conditions:
-  - condition: template
-    value_template: >
-      {% set last = this.attributes.last_triggered %}
-      {{ last is none or (now() - last).total_seconds() > 14400 }}
-  actions:
-  - variables:
-      hottest: "{{ state_attr('sensor.warehouse_max_heat_index', 'hottest_area') }}"
-      hi: "{{ states('sensor.warehouse_max_heat_index') | float(0) | round(0) | int }}"
-  - action: notify.make_nashville
-    data:
-      target: "#climate-feed"
-      message: |
-        :fire: *Warehouse is HOT*
-        *{{ hottest }}* is at *{{ hi }}°F heat index*. Take it seriously — drink water, take breaks, watch for signs of heat exhaustion in yourself and others.
-      data:
-        username: Climate Watch
-        icon: fire
-  mode: single
-
-- id: warehouse_heat_midday_confirmation
-  alias: Warehouse Heat — Midday Confirmation
-  description: Confirm the morning prediction at 12:30pm if it's actually hot now
-  triggers:
-  - trigger: time
-    at: "12:30:00"
-  conditions:
-  - condition: state
-    entity_id: input_boolean.warehouse_heat_morning_fired
-    state: "on"
-  - condition: template
-    value_template: >
-      {{ states('input_datetime.warehouse_heat_morning_fired_at') == now().strftime('%Y-%m-%d') }}
-  - condition: numeric_state
-    entity_id: sensor.warehouse_max_heat_index
-    above: 80
-  actions:
-  - variables:
-      hottest: "{{ state_attr('sensor.warehouse_max_heat_index', 'hottest_area') }}"
-      hi: "{{ states('sensor.warehouse_max_heat_index') | float(0) | round(0) | int }}"
-  - action: notify.make_nashville
-    data:
-      target: "#climate-feed"
-      message: |
-        :fire: *Yep, it's hot in here*
-        Right now the *{{ hottest }}* is the warmest at *{{ hi }}°F heat index*. Take breaks, hydrate, look out for each other.
-      data:
-        username: Climate Watch
-        icon: fire
-  mode: single
-
 - id: warehouse_heat_morning_headsup
   alias: Warehouse Climate — Daily Forecast
-  description: 7am daily forecast post; tiered messaging (chilly/comfortable/hot) and sets helpers on hot days
+  description: 7am daily forecast post; tiered messaging (chilly/comfortable/warm) based on forecast peak temperature
   triggers:
   - trigger: time
     at: "07:00:00"
@@ -474,76 +373,53 @@
         {% for e in entries %}
           {% set dt = e.datetime | as_datetime %}
           {% if dt.date() == today and dt.hour >= 9 and dt.hour <= 20 %}
-            {% set t = e.temperature | float(0) %}
-            {% set rh = e.humidity | float(0) %}
-            {% if t < 80 %}
-              {% set hi = t %}
-            {% else %}
-              {% set hi = -42.379
-                + 2.04901523 * t
-                + 10.14333127 * rh
-                - 0.22475541 * t * rh
-                - 0.00683783 * t * t
-                - 0.05481717 * rh * rh
-                + 0.00122874 * t * t * rh
-                + 0.00085282 * t * rh * rh
-                - 0.00000199 * t * t * rh * rh %}
-            {% endif %}
-            {% set ns.items = ns.items + [{'hi': hi, 'hour': dt.hour, 'temp': t, 'rh': rh}] %}
+            {% set ns.items = ns.items + [{'temp': e.temperature | float(0), 'hour': dt.hour}] %}
           {% endif %}
         {% endfor %}
         {{ ns.items }}
-      peak_hi: >
-        {% set hi_values = forecast_today | map(attribute='hi') | list %}
-        {{ (hi_values | max | round(0) | int) if hi_values else 0 }}
+      peak_temp: >
+        {% set temps = forecast_today | map(attribute='temp') | list %}
+        {{ (temps | max | round(0) | int) if temps else 0 }}
       peak_hour: >
-        {% set sorted = forecast_today | sort(attribute='hi', reverse=true) | list %}
+        {% set sorted = forecast_today | sort(attribute='temp', reverse=true) | list %}
         {{ sorted[0].hour if sorted else 0 }}
   - choose:
     - conditions:
       - condition: template
-        value_template: "{{ peak_hi >= 80 }}"
+        value_template: "{{ peak_temp >= 80 }}"
       sequence:
       - action: notify.make_nashville
         data:
           target: "#climate-feed"
           message: |
-            :sun_with_face: *Heads up — it's going to be hot today*
-            Forecast peak: *{{ peak_hi }}°F heat index* around {{ (peak_hour % 12) if (peak_hour % 12) != 0 else 12 }}{{ 'am' if peak_hour < 12 else 'pm' }}.
+            :sun_with_face: *Heads up — it's going to be warm today*
+            Forecast peak: *{{ peak_temp }}°F* around {{ (peak_hour % 12) if (peak_hour % 12) != 0 else 12 }}{{ 'am' if peak_hour < 12 else 'pm' }}.
             The warehouse usually runs warmer than outside. Dress light, bring water, plan breaks.
           data:
             username: Climate Watch
             icon: sun_with_face
-      - action: input_boolean.turn_on
-        target:
-          entity_id: input_boolean.warehouse_heat_morning_fired
-      - action: input_datetime.set_datetime
-        target:
-          entity_id: input_datetime.warehouse_heat_morning_fired_at
-        data:
-          date: "{{ now().strftime('%Y-%m-%d') }}"
     - conditions:
       - condition: template
-        value_template: "{{ peak_hi >= 65 and peak_hi < 80 }}"
+        value_template: "{{ peak_temp >= 65 and peak_temp < 80 }}"
       sequence:
       - action: notify.make_nashville
         data:
           target: "#climate-feed"
           message: |
-            :sun_with_face: *Today's forecast: peak around {{ peak_hi }}°F*
+            :sun_with_face: *Today's forecast: peak around {{ peak_temp }}°F*
             Comfortable conditions in the warehouse.
           data:
             username: Climate Watch
             icon: sun_with_face
     - conditions:
       - condition: template
-        value_template: "{{ peak_hi > 0 and peak_hi < 65 }}"
+        value_template: "{{ peak_temp > 0 and peak_temp < 65 }}"
       sequence:
       - action: notify.make_nashville
         data:
           target: "#climate-feed"
           message: |
-            :cold_face: *Today's forecast: peak around {{ peak_hi }}°F*
+            :cold_face: *Today's forecast: peak around {{ peak_temp }}°F*
             Chilly day ahead — layer up if you're stopping by.
           data:
             username: Climate Watch
@@ -551,14 +427,14 @@
   mode: single
 
 - id: warehouse_heat_hourly_status
-  alias: Warehouse Heat — Hourly Status
-  description: Hourly per-area temp/humidity/heat-index post to #climate-feed while the max indoor heat index is above 80°F
+  alias: Warehouse Climate — Hourly Status
+  description: Hourly per-area temperature/humidity post to #climate-feed while the max indoor temperature is above 80°F
   triggers:
   - trigger: time_pattern
     hours: /1
   conditions:
   - condition: numeric_state
-    entity_id: sensor.warehouse_max_heat_index
+    entity_id: sensor.warehouse_max_temperature
     above: 80
   actions:
   - variables:
@@ -566,62 +442,43 @@
         - name: Woodshop
           temp: sensor.woodshop_climate_sensor_temperature
           humidity: sensor.woodshop_climate_sensor_humidity
-          hi: sensor.woodshop_heat_index
         - name: 3D Print Room
           temp: sensor.air_quality_temperature
           humidity: sensor.air_quality_humidity
-          hi: sensor.3d_print_heat_index
         - name: Ceramics
           temp: sensor.ceramics_climate_sensor_temperature
           humidity: sensor.ceramics_climate_sensor_humidity
-          hi: sensor.ceramics_heat_index
         - name: Front Hallway
           temp: sensor.front_hallway_climate_sensor_temperature
           humidity: sensor.front_hallway_climate_sensor_humidity
-          hi: sensor.front_hallway_heat_index
   - action: notify.make_nashville
     data:
       target: "#climate-feed"
       data:
         username: Climate Watch
-        icon: thermometer
+        icon: sun_with_face
       message: |
-        {% set max_hi = states('sensor.warehouse_max_heat_index') | float(0) -%}
-        {% set title_icon = ':fire:' if max_hi >= 103 else ':hot_face:' if max_hi >= 90 else ':thermometer:' -%}
-        {% set care_line = '\nDangerous heat. Limit time in there. Watch yourselves and each other.' if max_hi >= 103 else '\nStress conditions. Water, breaks, check on each other.' if max_hi >= 90 else '' -%}
+        {% set max_temp = states('sensor.warehouse_max_temperature') | float(0) -%}
+        {% set title_icon = ':fire:' if max_temp >= 95 else ':hot_face:' if max_temp >= 88 else ':sun_with_face:' -%}
+        {% set care_line = '\nDangerous heat. Limit time in there. Watch yourselves and each other.' if max_temp >= 95 else '\nStress conditions. Water, breaks, check on each other.' if max_temp >= 88 else '' -%}
         {{ title_icon }} *Warehouse Climate — Hourly*
         *{{ now().strftime('%a, %b %-d  %-I:%M %p') }}*
 
-        Currently warmest: *{{ state_attr('sensor.warehouse_max_heat_index', 'hottest_area') }}* — {{ max_hi | round(0) | int }}°F HI
+        Currently warmest: *{{ state_attr('sensor.warehouse_max_temperature', 'hottest_area') }}* — {{ max_temp | round(0) | int }}°F
 
         {% for a in indoor_areas -%}
         {% set t_raw = states(a.temp) -%}
         {% set h_raw = states(a.humidity) -%}
-        {% set hi_raw = states(a.hi) -%}
-        {% if t_raw not in ['unknown','unavailable',none] and h_raw not in ['unknown','unavailable',none] and hi_raw not in ['unknown','unavailable',none] -%}
+        {% if t_raw not in ['unknown','unavailable',none] and h_raw not in ['unknown','unavailable',none] -%}
         {% set t = t_raw | float(0) -%}
         {% set h = h_raw | float(0) -%}
-        {% set hi = hi_raw | float(0) -%}
-        {% set icon = ':rotating_light:' if hi >= 103 else ':hot_face:' if hi >= 90 else ':warning:' if hi >= 85 else ':white_check_mark:' -%}
-        {{ icon }} {{ "%-17s"|format(a.name) }} {{ "%.1f°F"|format(t) }}  {{ h | round(0) | int }}%  → {{ hi | round(0) | int }}°F HI
+        {% set icon = ':rotating_light:' if t >= 95 else ':hot_face:' if t >= 88 else ':warning:' if t >= 82 else ':white_check_mark:' -%}
+        {{ icon }} {{ "%-17s"|format(a.name) }} {{ "%.1f°F"|format(t) }}  {{ h | round(0) | int }}%
         {% endif -%}
         {% endfor -%}
         {% set ot = state_attr('weather.forecast_home','temperature') | float(0) -%}
         {% set orh = state_attr('weather.forecast_home','humidity') | float(0) -%}
-        {% if ot < 80 -%}
-        {% set out_hi = ot -%}
-        {% else -%}
-        {% set out_hi = -42.379
-          + 2.04901523 * ot
-          + 10.14333127 * orh
-          - 0.22475541 * ot * orh
-          - 0.00683783 * ot * ot
-          - 0.05481717 * orh * orh
-          + 0.00122874 * ot * ot * orh
-          + 0.00085282 * ot * orh * orh
-          - 0.00000199 * ot * ot * orh * orh -%}
-        {% endif -%}
-        {% set out_icon = ':rotating_light:' if out_hi >= 103 else ':hot_face:' if out_hi >= 90 else ':warning:' if out_hi >= 85 else ':white_check_mark:' -%}
-        {{ out_icon }} {{ "%-17s"|format('Outside') }} {{ "%.1f°F"|format(ot) }}  {{ orh | round(0) | int }}%  → {{ out_hi | round(0) | int }}°F HI
+        {% set out_icon = ':rotating_light:' if ot >= 95 else ':hot_face:' if ot >= 88 else ':warning:' if ot >= 82 else ':white_check_mark:' -%}
+        {{ out_icon }} {{ "%-17s"|format('Outside') }} {{ "%.1f°F"|format(ot) }}  {{ orh | round(0) | int }}%
         {{ care_line -}}
   mode: single

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -140,16 +140,6 @@ input_boolean:
   deploy_restart_in_progress:
     name: Deploy Restart In Progress
     icon: mdi:restart
-  warehouse_heat_morning_fired:
-    name: Warehouse Heat Morning Fired
-    icon: mdi:weather-sunny-alert
-
-input_datetime:
-  warehouse_heat_morning_fired_at:
-    name: Warehouse Heat Morning Fired At
-    has_date: true
-    has_time: false
-    icon: mdi:calendar-clock
 
 recorder:
   purge_keep_days: 14
@@ -388,129 +378,25 @@ template:
         state: >
           {{states('sensor.dragonfruit_filename').replace(states('sensor.dragonfruit_display_name') + '-', '')}}
 
-      - name: "Woodshop Heat Index"
-        unique_id: woodshop_heat_index
-        unit_of_measurement: "°F"
-        device_class: temperature
-        state_class: measurement
-        availability: >
-          {{ states('sensor.woodshop_climate_sensor_temperature') not in ['unknown', 'unavailable']
-             and states('sensor.woodshop_climate_sensor_humidity') not in ['unknown', 'unavailable'] }}
-        state: >
-          {% set t = states('sensor.woodshop_climate_sensor_temperature') | float(0) %}
-          {% set rh = states('sensor.woodshop_climate_sensor_humidity') | float(0) %}
-          {% if t < 80 %}
-            {{ t | round(1) }}
-          {% else %}
-            {% set hi = -42.379
-              + 2.04901523 * t
-              + 10.14333127 * rh
-              - 0.22475541 * t * rh
-              - 0.00683783 * t * t
-              - 0.05481717 * rh * rh
-              + 0.00122874 * t * t * rh
-              + 0.00085282 * t * rh * rh
-              - 0.00000199 * t * t * rh * rh %}
-            {{ hi | round(1) }}
-          {% endif %}
-
-      - name: "3D Print Heat Index"
-        unique_id: 3d_print_heat_index
-        unit_of_measurement: "°F"
-        device_class: temperature
-        state_class: measurement
-        availability: >
-          {{ states('sensor.air_quality_temperature') not in ['unknown', 'unavailable']
-             and states('sensor.air_quality_humidity') not in ['unknown', 'unavailable'] }}
-        state: >
-          {% set t = states('sensor.air_quality_temperature') | float(0) %}
-          {% set rh = states('sensor.air_quality_humidity') | float(0) %}
-          {% if t < 80 %}
-            {{ t | round(1) }}
-          {% else %}
-            {% set hi = -42.379
-              + 2.04901523 * t
-              + 10.14333127 * rh
-              - 0.22475541 * t * rh
-              - 0.00683783 * t * t
-              - 0.05481717 * rh * rh
-              + 0.00122874 * t * t * rh
-              + 0.00085282 * t * rh * rh
-              - 0.00000199 * t * t * rh * rh %}
-            {{ hi | round(1) }}
-          {% endif %}
-
-      - name: "Ceramics Heat Index"
-        unique_id: ceramics_heat_index
-        unit_of_measurement: "°F"
-        device_class: temperature
-        state_class: measurement
-        availability: >
-          {{ states('sensor.ceramics_climate_sensor_temperature') not in ['unknown', 'unavailable']
-             and states('sensor.ceramics_climate_sensor_humidity') not in ['unknown', 'unavailable'] }}
-        state: >
-          {% set t = states('sensor.ceramics_climate_sensor_temperature') | float(0) %}
-          {% set rh = states('sensor.ceramics_climate_sensor_humidity') | float(0) %}
-          {% if t < 80 %}
-            {{ t | round(1) }}
-          {% else %}
-            {% set hi = -42.379
-              + 2.04901523 * t
-              + 10.14333127 * rh
-              - 0.22475541 * t * rh
-              - 0.00683783 * t * t
-              - 0.05481717 * rh * rh
-              + 0.00122874 * t * t * rh
-              + 0.00085282 * t * rh * rh
-              - 0.00000199 * t * t * rh * rh %}
-            {{ hi | round(1) }}
-          {% endif %}
-
-      - name: "Front Hallway Heat Index"
-        unique_id: front_hallway_heat_index
-        unit_of_measurement: "°F"
-        device_class: temperature
-        state_class: measurement
-        availability: >
-          {{ states('sensor.front_hallway_climate_sensor_temperature') not in ['unknown', 'unavailable']
-             and states('sensor.front_hallway_climate_sensor_humidity') not in ['unknown', 'unavailable'] }}
-        state: >
-          {% set t = states('sensor.front_hallway_climate_sensor_temperature') | float(0) %}
-          {% set rh = states('sensor.front_hallway_climate_sensor_humidity') | float(0) %}
-          {% if t < 80 %}
-            {{ t | round(1) }}
-          {% else %}
-            {% set hi = -42.379
-              + 2.04901523 * t
-              + 10.14333127 * rh
-              - 0.22475541 * t * rh
-              - 0.00683783 * t * t
-              - 0.05481717 * rh * rh
-              + 0.00122874 * t * t * rh
-              + 0.00085282 * t * rh * rh
-              - 0.00000199 * t * t * rh * rh %}
-            {{ hi | round(1) }}
-          {% endif %}
-
-      - name: "Warehouse Max Heat Index"
-        unique_id: warehouse_max_heat_index
+      - name: "Warehouse Max Temperature"
+        unique_id: warehouse_max_temperature
         unit_of_measurement: "°F"
         device_class: temperature
         state_class: measurement
         availability: >
           {{ [
-               states('sensor.woodshop_heat_index'),
-               states('sensor.3d_print_heat_index'),
-               states('sensor.ceramics_heat_index'),
-               states('sensor.front_hallway_heat_index')
+               states('sensor.woodshop_climate_sensor_temperature'),
+               states('sensor.air_quality_temperature'),
+               states('sensor.ceramics_climate_sensor_temperature'),
+               states('sensor.front_hallway_climate_sensor_temperature')
              ] | reject('in', ['unknown', 'unavailable']) | list | length > 0 }}
         state: >
           {% set best = namespace(val=-1000, any=false) %}
           {% for entity in [
-            'sensor.woodshop_heat_index',
-            'sensor.3d_print_heat_index',
-            'sensor.ceramics_heat_index',
-            'sensor.front_hallway_heat_index'
+            'sensor.woodshop_climate_sensor_temperature',
+            'sensor.air_quality_temperature',
+            'sensor.ceramics_climate_sensor_temperature',
+            'sensor.front_hallway_climate_sensor_temperature'
           ] %}
             {% set s = states(entity) %}
             {% if s not in ['unknown', 'unavailable'] %}
@@ -524,10 +410,10 @@ template:
           hottest_area: >
             {% set best = namespace(name='unknown', val=-1000) %}
             {% for name, entity in [
-              ('Woodshop',       'sensor.woodshop_heat_index'),
-              ('3D Print Room',  'sensor.3d_print_heat_index'),
-              ('Ceramics',       'sensor.ceramics_heat_index'),
-              ('Front Hallway',  'sensor.front_hallway_heat_index')
+              ('Woodshop',       'sensor.woodshop_climate_sensor_temperature'),
+              ('3D Print Room',  'sensor.air_quality_temperature'),
+              ('Ceramics',       'sensor.ceramics_climate_sensor_temperature'),
+              ('Front Hallway',  'sensor.front_hallway_climate_sensor_temperature')
             ] %}
               {% set s = states(entity) %}
               {% if s not in ['unknown', 'unavailable'] %}
@@ -539,19 +425,6 @@ template:
               {% endif %}
             {% endfor %}
             {{ best.name }}
-          hottest_area_temperature: >
-            {% set name_to_temp = {
-              'Woodshop':       'sensor.woodshop_climate_sensor_temperature',
-              '3D Print Room':  'sensor.air_quality_temperature',
-              'Ceramics':       'sensor.ceramics_climate_sensor_temperature',
-              'Front Hallway':  'sensor.front_hallway_climate_sensor_temperature'
-            } %}
-            {% set hottest = state_attr('sensor.warehouse_max_heat_index', 'hottest_area') %}
-            {% if hottest in name_to_temp %}
-              {{ states(name_to_temp[hottest]) | float(0) | round(1) }}
-            {% else %}
-              0
-            {% endif %}
 
 sensor:
   # Weekly print counts — used by the Sunday metrics automation


### PR DESCRIPTION
## Summary

Simplifies the #climate-feed channel to two posts per day cycle (7am forecast + hourly status while warm), both in raw °F. Real-time alerts and the heat-index math are gone.

### Removed automations
- `warehouse_heat_realtime_warm` (>88°F HI for 10min alert)
- `warehouse_heat_realtime_hot` (>95°F HI for 10min alert)
- `warehouse_heat_midday_confirmation` (12:30pm follow-up)
- `warehouse_heat_daily_reset` (midnight flag clear — no longer needed)

### Rewritten automations
- **`warehouse_heat_morning_headsup`** (alias renamed to *Warehouse Climate — Daily Forecast*): triggers tiered messaging off `peak_temp` from the hourly weather forecast instead of computed peak heat index. No longer sets the morning-fired helpers.
- **`warehouse_heat_hourly_status`** (alias renamed to *Warehouse Climate — Hourly Status*): triggers off `sensor.warehouse_max_temperature` > 80°F. Per-row icons scale on raw °F (warning 82, hot_face 88, rotating_light 95). Title icon scales likewise (sun_with_face / hot_face / fire). The `→ XX°F HI` suffix and the `:thermometer:` emoji are gone; Slack avatar is now `sun_with_face`.

### Sensor / helper cleanup (`configuration.yaml`)
- Deleted: `sensor.woodshop_heat_index`, `sensor.3d_print_heat_index`, `sensor.ceramics_heat_index`, `sensor.front_hallway_heat_index`, `sensor.warehouse_max_heat_index`.
- Added: `sensor.warehouse_max_temperature` — same shape as the old aggregator (state = max raw °F, `hottest_area` attribute) but built from the four raw temperature sensors instead of derived HI sensors.
- Dropped `input_boolean.warehouse_heat_morning_fired` and the entire `input_datetime:` block (only entry was `warehouse_heat_morning_fired_at`). Both existed solely to support the removed midday confirmation.

## Test plan

- [ ] YAML validation passes (`validate-yaml.yml`)
- [ ] On deploy, HA registers the renamed aliases and the new `warehouse_max_temperature` template sensor without errors
- [ ] `sensor.warehouse_max_temperature` reports a sensible °F value and `hottest_area` attribute
- [ ] No HA log warnings about missing `warehouse_heat_morning_fired*` entities
- [ ] Manually trigger the daily forecast and hourly status from Developer Tools and confirm the Slack post looks right (no thermometer emoji, no "°F HI" string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)