### PR TITLE
rename(climate-feed): Ceramics display label to Metalshop

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -445,7 +445,7 @@
         - name: 3D Print Room
           temp: sensor.air_quality_temperature
           humidity: sensor.air_quality_humidity
-        - name: Ceramics
+        - name: Metalshop
           temp: sensor.ceramics_climate_sensor_temperature
           humidity: sensor.ceramics_climate_sensor_humidity
         - name: Front Hallway

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -412,7 +412,7 @@ template:
             {% for name, entity in [
               ('Woodshop',       'sensor.woodshop_climate_sensor_temperature'),
               ('3D Print Room',  'sensor.air_quality_temperature'),
-              ('Ceramics',       'sensor.ceramics_climate_sensor_temperature'),
+              ('Metalshop',      'sensor.ceramics_climate_sensor_temperature'),
               ('Front Hallway',  'sensor.front_hallway_climate_sensor_temperature')
             ] %}
               {% set s = states(entity) %}

--- a/dashboards/facilities.yaml
+++ b/dashboards/facilities.yaml
@@ -48,7 +48,7 @@ views:
                 name: Humidity
 
           - type: glance
-            title: Ceramics
+            title: Metalshop
             entities:
               - entity: sensor.ceramics_climate_sensor_temperature
                 name: Temperature


### PR DESCRIPTION
## Summary

The space we'd been calling "Ceramics" in the climate-feed posts and on the Facilities dashboard is actually the metal shop. One-word `Metalshop` matches the existing `Woodshop` convention.

Three user-facing strings updated:

- `automations/facilities.yaml` — `indoor_areas` `name:` in the hourly status template
- `configuration.yaml` — `hottest_area` attribute lookup on `sensor.warehouse_max_temperature`
- `dashboards/facilities.yaml` — glance card title

The underlying entity IDs (`sensor.ceramics_climate_sensor_temperature` / `_humidity`) and the device name in HA are device-registry-owned and have to be renamed from the HA UI (Settings → Devices → that device → rename). Out of scope for this PR.

## Notes

PR #117 (climate-feed simplification) merged into main first; this branch is based on top of it, so the rename lands in the new structure (no `hi:` field, no `warehouse_max_heat_index` references).

## Test plan

- [ ] YAML validation passes (`validate-yaml.yml`)
- [ ] After deploy, the next hourly climate post lists "Metalshop" instead of "Ceramics"
- [ ] Facilities dashboard glance card shows "Metalshop" as the title
- [ ] `state_attr('sensor.warehouse_max_temperature', 'hottest_area')` returns `Metalshop` when that area is the hottest

🤖 Generated with [Claude Code](https://claude.com/claude-code)