### PR TITLE
Use NWS as sole outdoor source in hourly climate feed

### DIFF
--- a/automations/facilities.yaml
+++ b/automations/facilities.yaml
@@ -491,9 +491,7 @@
         {% endif -%}
         {% endfor -%}
         {% set wx_sources = [
-          ('Outside (Met)', 'weather.forecast_home'),
-          ('Outside (NWS)', 'weather.outside_nws_make_nashville_kbna'),
-          ('Outside (O-M)', 'weather.make_nashville'),
+          ('Outside', 'weather.outside_nws_make_nashville_kbna'),
         ] -%}
         {% for label, entity in wx_sources -%}
         {% if state_attr(entity, 'temperature') is not none -%}


### PR DESCRIPTION
## Summary
- Reverts the hourly climate feed to a single outdoor weather source (NWS: `weather.outside_nws_make_nashville_kbna`), removing Met.no and Open-Meteo which were added in #122

## Test plan
- [ ] YAML validation passes in CI
- [ ] After deploy, confirm the hourly `#climate-feed` message shows one `Outside` line sourced from NWS

🤖 Generated with [Claude Code](https://claude.com/claude-code)